### PR TITLE
許可するホスト追加

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -90,4 +90,7 @@ Rails.application.configure do
 
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
+  
+  # 「from-your-desk.onrender.com」を許可するホストに追加（デプロイ時にエラーが出るため）
+  config.hosts << "from-your-desk.onrender.com"
 end


### PR DESCRIPTION
# 概要
renderで初期デプロイ時にホストの許可が降りてないエラーが発生したため対応。
[![Image from Gyazo](https://i.gyazo.com/fba0cf0695492d64761427aaf4dcd6cc.png)](https://gyazo.com/fba0cf0695492d64761427aaf4dcd6cc)

## 対策
config/environments/production.rbに下記を追記。
```ruby
  # 「from-your-desk.onrender.com」を許可するホストに追加（デプロイ時にエラーが出るため）
  config.hosts << "from-your-desk.onrender.com"
```