### PR TITLE
database.yml修正

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -17,14 +17,14 @@
 default: &default
   adapter: postgresql
   encoding: unicode
-  host: db # データベースのホスト名（データベースのコンテナ名）
-  username: postgres # データベースに接続する際のユーザ名
-  password: password # データベースのパスワード
   pool: 5  # データベースコネクションプールのサイズ。
 
 development:
   <<: *default
   database: app_development
+  host: db # データベースのホスト名（データベースのコンテナ名）
+  username: postgres # データベースに接続する際のユーザ名
+  password: password # データベースのパスワード
 
   # The specified database role being used to connect to postgres.
   # To create additional roles in postgres see `$ createuser --help`.


### PR DESCRIPTION
# 概要
database.yml 修正

## 内容
host,username,passwordをdefaultからdevelopment,testに移行。（puroduct環境でhost名の指定をしないため）
```ruby
default: &default
  adapter: postgresql
  encoding: unicode
  pool: 5  # データベースコネクションプールのサイズ。

development:
  <<: *default
  database: app_development
  host: db # データベースのホスト名（データベースのコンテナ名）
  username: postgres # データベースに接続する際のユーザ名
  password: password # データベースのパスワード
```