### PR TITLE
フラッシュメッセージのテキストカラー修正

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -29,4 +29,15 @@ module ApplicationHelper
             }
         }
     end
+
+    def flash_class(message_type)
+        case message_type.to_sym
+        when :success
+        'text-sky-600'
+        when :danger
+        'text-red-500'
+        else
+        'text-gray-500'
+        end
+    end
 end

--- a/app/views/shared/_error_messages.html.erb
+++ b/app/views/shared/_error_messages.html.erb
@@ -1,9 +1,11 @@
-<% if object.errors.any? %>
-  <div id="error_explanation" class="text-red-500">
-    <ul>
-      <% object.errors.each do |error| %>
-        <li><%= error.full_message %></li>
-      <% end %>
-    </ul>
-  </div>
-<% end %>
+<div class="inline-block rounded m-2 px-2 bg-red-200">
+  <% if object.errors.any? %>
+    <div id="error_explanation" class="font-bold text-red-500">
+      <ul>
+        <% object.errors.each do |error| %>
+          <li>※<%= error.full_message %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+</div>

--- a/app/views/shared/_flash_message.html.erb
+++ b/app/views/shared/_flash_message.html.erb
@@ -1,6 +1,6 @@
-<div class="inline-block rounded m-2 px-2 bg-teal-300">
-  <% flash.each do |message_type, message|%>
-    <div class="m-3 alert bg-<%= message_type %>">
+<div class="inline-block rounded m-2 px-2 bg-slate-200">
+  <% flash.each do |message_type, message| %>
+    <div class="m-3 font-bold alert <%= flash_class(message_type) %>">
       <%= message %>
     </div>
   <% end %>


### PR DESCRIPTION
#126 

# 概要
フラッシュメッセージのテキストカラーが黒だけになっていたので、success時とdanger時で動的に変更するよう修正。

# 内容
成功時のフラッシュメッセージ
[![Image from Gyazo](https://i.gyazo.com/af4e7d41b4d62e0534d4b3e206f7208b.png)](https://gyazo.com/af4e7d41b4d62e0534d4b3e206f7208b)
失敗時のフラッシュメッセージ
[![Image from Gyazo](https://i.gyazo.com/2bbbc87eba2d381ae744cc8c34f00f2d.png)](https://gyazo.com/2bbbc87eba2d381ae744cc8c34f00f2d)

# 内容
message_typeをhelperディレクトリに追加。
ビューにて動的に表示を変更。
・app/helpers/application_helper.rb
```ruby
module ApplicationHelper


    def flash_class(message_type)
        case message_type.to_sym
        when :success
        'text-sky-600'
        when :danger
        'text-red-500'
        else
        'text-gray-500'
        end
    end
end

```

・app/views/shared/_flash_message.html.erb
```ruby
<div class="inline-block rounded m-2 px-2 bg-slate-200">
  <% flash.each do |message_type, message| %>
    <div class="m-3 font-bold alert <%= flash_class(message_type) %>">
      <%= message %>
    </div>
  <% end %>
</div>
```