### PR TITLE
item関連ヘッダーメニュー作成

### DIFF
--- a/app/javascript/menu.js
+++ b/app/javascript/menu.js
@@ -1,19 +1,38 @@
 document.addEventListener('turbo:load', (event) => {
     const menuButton = document.getElementById('menu-button');
-    const menu = document.querySelector('[role="menu"]');
+    const diagnosisMenuButton = document.getElementById('diagnosis_menu-button');
+    const itemMenuButton = document.getElementById('item_menu-button');
+    const menu = document.querySelector('[aria-labelledby="menu-button"]');
+    const diagnosisMenu = document.querySelector('[aria-labelledby="diagnosis_menu-button"]');
+    const itemMenu = document.querySelector('[aria-labelledby="item_menu-button"]');
 
-    if (menuButton) {
-        // 初期状態ではメニューを非表示にする
+    if (menuButton && menu) {
         menu.style.display = 'none';
+        menuButton.addEventListener('click', (event) => {
+            menu.style.display = (menu.style.display === 'none') ? 'block' : 'none';
+            event.stopPropagation();
+        });
+    };
 
-        // メニューボタンがクリックされたときのイベントリスナーを設定
-        menuButton.addEventListener('click', () => {
-            // メニューが表示されている場合は非表示にし、非表示の場合は表示する
-            if (menu.style.display === 'none') {
-                menu.style.display = 'block';
-            } else {
-                menu.style.display = 'none';
-            }
+    if (diagnosisMenuButton && diagnosisMenu) {
+        diagnosisMenu.style.display = 'none';
+        diagnosisMenuButton.addEventListener('click', (event) => {
+            diagnosisMenu.style.display = (diagnosisMenu.style.display === 'none') ? 'block' : 'none';
+            event.stopPropagation();
+        });
+    };
+
+    if (itemMenuButton && itemMenu) {
+        itemMenu.style.display = 'none';
+        itemMenuButton.addEventListener('click', (event) => {
+            itemMenu.style.display = (itemMenu.style.display === 'none') ? 'block' : 'none';
+            event.stopPropagation();
         });
     }
+
+    document.addEventListener('click', () => {
+        if (menu) menu.style.display = 'none';
+        if (diagnosisMenu) diagnosisMenu.style.display = 'none';
+        if (itemMenu) itemMenu.style.display = 'none';
+    });
 });

--- a/app/javascript/menu.js
+++ b/app/javascript/menu.js
@@ -2,37 +2,48 @@ document.addEventListener('turbo:load', (event) => {
     const menuButton = document.getElementById('menu-button');
     const diagnosisMenuButton = document.getElementById('diagnosis_menu-button');
     const itemMenuButton = document.getElementById('item_menu-button');
+    const smallMenuButton = document.getElementById('small_menu-button');
+
     const menu = document.querySelector('[aria-labelledby="menu-button"]');
     const diagnosisMenu = document.querySelector('[aria-labelledby="diagnosis_menu-button"]');
     const itemMenu = document.querySelector('[aria-labelledby="item_menu-button"]');
+    const smallMenu = document.querySelector('[aria-labelledby="small_menu-button"]');
 
-    if (menuButton && menu) {
-        menu.style.display = 'none';
-        menuButton.addEventListener('click', (event) => {
-            menu.style.display = (menu.style.display === 'none') ? 'block' : 'none';
-            event.stopPropagation();
-        });
+    const toggleMenu = (button, menu) => {
+        if (button && menu) {
+            menu.style.display = 'none';
+            let isHovering = false;
+
+            const openMenu = () => {
+                isHovering = true;
+                menu.style.display = 'block';
+            };
+
+            const closeMenu = () => {
+                isHovering = false;
+                setTimeout(() => {
+                    if (!isHovering) {
+                        menu.style.display = 'none';
+                    }
+                }, 10);
+            };
+
+            button.addEventListener('mouseover', openMenu);
+            button.addEventListener('mouseout', closeMenu);
+            menu.addEventListener('mouseover', openMenu);
+            menu.addEventListener('mouseout', closeMenu);
+        }
     };
 
-    if (diagnosisMenuButton && diagnosisMenu) {
-        diagnosisMenu.style.display = 'none';
-        diagnosisMenuButton.addEventListener('click', (event) => {
-            diagnosisMenu.style.display = (diagnosisMenu.style.display === 'none') ? 'block' : 'none';
-            event.stopPropagation();
-        });
-    };
-
-    if (itemMenuButton && itemMenu) {
-        itemMenu.style.display = 'none';
-        itemMenuButton.addEventListener('click', (event) => {
-            itemMenu.style.display = (itemMenu.style.display === 'none') ? 'block' : 'none';
-            event.stopPropagation();
-        });
-    }
+    toggleMenu(menuButton, menu);
+    toggleMenu(diagnosisMenuButton, diagnosisMenu);
+    toggleMenu(itemMenuButton, itemMenu);
+    toggleMenu(smallMenuButton, smallMenu);
 
     document.addEventListener('click', () => {
         if (menu) menu.style.display = 'none';
         if (diagnosisMenu) diagnosisMenu.style.display = 'none';
         if (itemMenu) itemMenu.style.display = 'none';
+        if (smallMenu) smallMenu.style.display = 'none';
     });
 });

--- a/app/views/shared/_before_login_header.html.erb
+++ b/app/views/shared/_before_login_header.html.erb
@@ -17,6 +17,7 @@
           </svg>
         </button>
       </div>
+      
       <div class="absolute right-0 z-10 mt-2 w-56 origin-top-right divide-y divide-gray-100 rounded-md bg-white shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none" role="menu" aria-orientation="vertical" aria-labelledby="menu-button" tabindex="-1">
         <div class="py-1" role="none">
           <%= link_to new_diagnosis_path, class: "flex items-center text-gray-700 px-4 py-2 text-sm hover:bg-teal-200 transition duration-150 ease-in-out", role: "menuitem", tabindex: "-1", id: "menu-item-0" do %>
@@ -28,6 +29,18 @@
           <%= link_to diagnoses_path, class: "flex items-center text-gray-700 block px-4 py-2 text-sm hover:bg-teal-200 transition duration-150 ease-in-out", role: "menuitem", tabindex: "-1", id: "menu-item-0" do %>
             <span class="material-icons mr-2">leaderboard</span>
             <%= t('header.diagnosis_index') %>
+          <% end %>
+        </div>
+        <div class="py-1" role="none">
+          <%= link_to items_path, class: "flex items-center text-gray-700 block px-4 py-2 text-sm hover:bg-teal-200 transition duration-150 ease-in-out", role: "menuitem", tabindex: "-1", id: "menu-item-0" do %>
+            <span class="material-icons mr-2">savings</span>
+            <%= t('header.item_index') %>
+          <% end %>
+        </div>
+        <div class="py-1" role="none">
+          <%= link_to new_item_path, class: "flex items-center text-gray-700 block px-4 py-2 text-sm hover:bg-teal-200 transition duration-150 ease-in-out", role: "menuitem", tabindex: "-1", id: "menu-item-0" do %>
+            <span class="material-icons mr-2">create</span>
+            <%= t('header.item_new_before_login') %>
           <% end %>
         </div>
         <div class="py-1" role="none">

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,64 +1,150 @@
 <header class="fixed top-0 w-full z-10 bg-white" >
-  <nav class="navbar py-2 px-2 flex justify-between items-center shadow-lg shadow-cyan-600/70">
-    <div class="font-bold text-3xl">
-      <h1><%= link_to t('header.title'), "/" %></h1>
-    </div>
-    
-    <div class="relative inline-block text-left">
-      <div class="flex items-center">
-        <div>
-          <button type="button" 
-                  class="inline-flex w-full justify-center gap-x-1.5 rounded-md bg-gray-200 px-3 py-2 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-teal-300" 
-                  id="menu-button" 
-                  aria-expanded="true" 
-                  aria-haspopup="true">
-            <span class="material-icons">reorder</span>
-            <svg class="-mr-1 h-5 w-5 text-gray-400" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-              <path fill-rule="evenodd" d="M5.23 7.21a.75.75 0 011.06.02L10 11.168l3.71-3.938a.75.75 0 111.08 1.04l-4.25 4.5a.75.75 0 01-1.08 0l-4.25-4.5a.75.75 0 01.02-1.06z" clip-rule="evenodd" />
-            </svg>
-          </button>
-        </div>
-        
-
-        <div class="ml-2">
-          <% if current_user.google_avatar_image.blank? %>
-            <%= image_tag current_user.avatar_image_url, class: "h-10 w-10 object-cove rounded-full object-cover" %>
-          <% else %>
-            <%= image_tag current_user.google_avatar_image, class: "h-10 w-10 object-cove rounded-full object-cover" %>
-          <% end %>
-        </div>
+  <nav class="navbar py-2 px-2 items-center shadow-lg shadow-cyan-600/70">
+    <div class="flex justify-between">
+      <div class="font-bold text-3xl">
+        <h1><%= link_to t('header.title'), "/" %></h1>
       </div>
 
-      <div class="absolute right-0 z-10 mt-2 w-56 origin-top-right divide-y divide-gray-100 rounded-md bg-white shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none" role="menu" aria-orientation="vertical" aria-labelledby="menu-button" tabindex="-1">
-        <div class="py-1" role="none">
-          <%= link_to new_diagnosis_path, class: "flex items-center text-gray-700 px-4 py-2 text-sm hover:bg-teal-200 transition duration-150 ease-in-out", role: "menuitem", tabindex: "-1", id: "menu-item-0" do %>
-            <span class="material-icons mr-2">visibility</span>
-            <%= t('header.diagnosis') %>
-          <% end %>
+    <!-- menu -->
+      <div>
+        <!-- diagnosis menu -->
+        <div class="relative inline-block text-left">
+          <div class="flex items-center">
+            <div>
+              <button type="button" 
+                      class="inline-flex w-full justify-center gap-x-1.5 rounded-md bg-gray-200 px-3 py-2 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-teal-300" 
+                      id="diagnosis_menu-button" 
+                      aria-expanded="true" 
+                      aria-haspopup="true">
+                <div class="flex items-center">
+                  <span class="material-icons mr-1">visibility</span>
+                  <%= t('header.diagnosis') %>
+                </div>
+                <svg class="-mr-1 h-5 w-5 text-gray-400" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+                  <path fill-rule="evenodd" d="M5.23 7.21a.75.75 0 011.06.02L10 11.168l3.71-3.938a.75.75 0 111.08 1.04l-4.25 4.5a.75.75 0 01-1.08 0l-4.25-4.5a.75.75 0 01.02-1.06z" clip-rule="evenodd" />
+                </svg>
+              </button>
+            </div>
+          </div>
+
+          <div class="absolute right-0 z-10 mt-2 w-56 origin-top-right divide-y divide-gray-100 rounded-md bg-white shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none" 
+                      role="menu" 
+                      aria-orientation="vertical" 
+                      aria-labelledby="diagnosis_menu-button" 
+                      tabindex="-1">
+            <div class="py-1" role="none">
+              <%= link_to new_diagnosis_path, class: "flex items-center text-gray-700 px-4 py-2 text-sm hover:bg-teal-200 transition duration-150 ease-in-out", role: "menuitem", tabindex: "-1", id: "menu-item-0" do %>
+                <span class="material-icons mr-2">visibility</span>
+                <%= t('header.diagnosis') %>
+              <% end %>
+            </div>
+            <div class="py-1" role="none">
+              <%= link_to diagnoses_path, class: "flex items-center text-gray-700 block px-4 py-2 text-sm hover:bg-teal-200 transition duration-150 ease-in-out", role: "menuitem", tabindex: "-1", id: "menu-item-0" do %>
+                <span class="material-icons mr-2">leaderboard</span>
+                <%= t('header.diagnosis_index') %>
+              <% end %>
+            </div>
+            <div class="py-1" role="none">
+              <%= link_to favorites_diagnoses_path, class: "flex items-center text-gray-700 block px-4 py-2 text-sm hover:bg-teal-200 transition duration-150 ease-in-out", role: "menuitem", tabindex: "-1", id: "menu-item-0" do %>
+                <span class="material-icons mr-2">thumb_up_off_alt</span>
+                <%= t('header.favorite_diagnoses') %>
+              <% end %>
+            </div>
+          </div>
         </div>
-        <div class="py-1" role="none">
-          <%= link_to diagnoses_path, class: "flex items-center text-gray-700 block px-4 py-2 text-sm hover:bg-teal-200 transition duration-150 ease-in-out", role: "menuitem", tabindex: "-1", id: "menu-item-0" do %>
-            <span class="material-icons mr-2">leaderboard</span>
-            <%= t('header.diagnosis_index') %>
-          <% end %>
+
+        <!-- item menu -->
+        <div class="relative inline-block text-left">
+          <div class="flex items-center">
+            <div>
+              <button type="button" 
+                      class="inline-flex w-full justify-center gap-x-1.5 rounded-md bg-gray-200 px-3 py-2 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-teal-300" 
+                      id="item_menu-button" 
+                      aria-expanded="true" 
+                      aria-haspopup="true">
+                <div class="flex items-center">
+                  <span class="material-icons mr-1">savings</span>
+                  <%= t('header.item') %>
+                </div>
+                <svg class="-mr-1 h-5 w-5 text-gray-400" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+                  <path fill-rule="evenodd" d="M5.23 7.21a.75.75 0 011.06.02L10 11.168l3.71-3.938a.75.75 0 111.08 1.04l-4.25 4.5a.75.75 0 01-1.08 0l-4.25-4.5a.75.75 0 01.02-1.06z" clip-rule="evenodd" />
+                </svg>
+              </button>
+            </div>
+          </div>
+
+          <div class="absolute right-0 z-10 mt-2 w-56 origin-top-right divide-y divide-gray-100 rounded-md bg-white shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none" 
+                      role="menu" 
+                      aria-orientation="vertical" 
+                      aria-labelledby="item_menu-button" 
+                      tabindex="-1">
+            <div class="py-1" role="none">
+              <%= link_to items_path, class: "flex items-center text-gray-700 block px-4 py-2 text-sm hover:bg-teal-200 transition duration-150 ease-in-out", role: "menuitem", tabindex: "-1", id: "menu-item-0" do %>
+                <span class="material-icons mr-2">savings</span>
+                <%= t('header.item_index') %>
+              <% end %>
+            </div>
+            <div class="py-1" role="none">
+              <%= link_to items_path, class: "flex items-center text-gray-700 block px-4 py-2 text-sm hover:bg-teal-200 transition duration-150 ease-in-out", role: "menuitem", tabindex: "-1", id: "menu-item-0" do %>
+                <span class="material-icons mr-2">bookmarks</span>
+                <%= t('header.bookmark_items') %>
+              <% end %>
+            </div>
+            <div class="py-1" role="none">
+              <%= link_to new_item_path, class: "flex items-center text-gray-700 block px-4 py-2 text-sm hover:bg-teal-200 transition duration-150 ease-in-out", role: "menuitem", tabindex: "-1", id: "menu-item-0" do %>
+                <span class="material-icons mr-2">create</span>
+                <%= t('header.item_new') %>
+              <% end %>
+            </div>
+          </div>
         </div>
-        <div class="py-1" role="none">
-          <%= link_to favorites_diagnoses_path, class: "flex items-center text-gray-700 block px-4 py-2 text-sm hover:bg-teal-200 transition duration-150 ease-in-out", role: "menuitem", tabindex: "-1", id: "menu-item-0" do %>
-            <span class="material-icons mr-2">thumb_up_off_alt</span>
-            <%= t('header.favorite_diagnoses') %>
-          <% end %>
-        </div>
-        <div class="py-1" role="none">
-          <%= link_to profile_path, class: "flex items-center text-gray-700 block px-4 py-2 text-sm hover:bg-teal-200 transition duration-150 ease-in-out", role: "menuitem", tabindex: "-1", id: "menu-item-0" do %>
-            <span class="material-icons mr-2">manage_accounts</span>
-            <%= t('header.profile') %>
-          <% end %>
-        </div>
-        <div class="py-1" role="none">
-          <%= link_to logout_path, class: "flex items-center text-gray-700 block px-4 py-2 text-sm hover:bg-teal-200 transition duration-150 ease-in-out", role: "menuitem", tabindex: "-1", id: "menu-item-0", data: { turbo_method: :delete } do %>
-            <span class="material-icons mr-2">logout</span>
-            <%= t('header.logout') %>
-          <% end %>
+
+        <!-- profile menu -->
+        <div class="relative inline-block text-left">
+          <div class="flex items-center">
+            <div>
+              <button type="button" 
+                      class="inline-flex w-full justify-center gap-x-1.5 rounded-md bg-gray-200 px-3 py-2 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-teal-300" 
+                      id="menu-button" 
+                      aria-expanded="true" 
+                      aria-haspopup="true">
+                <div class="flex items-center">
+                  <span class="material-icons">manage_accounts</span>
+                  <%= t('header.profile') %>
+                </div>
+                <svg class="-mr-1 h-5 w-5 text-gray-400" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+                  <path fill-rule="evenodd" d="M5.23 7.21a.75.75 0 011.06.02L10 11.168l3.71-3.938a.75.75 0 111.08 1.04l-4.25 4.5a.75.75 0 01-1.08 0l-4.25-4.5a.75.75 0 01.02-1.06z" clip-rule="evenodd" />
+                </svg>
+              </button>
+            </div>
+
+            <div class="ml-2">
+              <% if current_user.google_avatar_image.blank? %>
+                <%= image_tag current_user.avatar_image_url, class: "h-10 w-10 object-cove rounded-full object-cover" %>
+              <% else %>
+                <%= image_tag current_user.google_avatar_image, class: "h-10 w-10 object-cove rounded-full object-cover" %>
+              <% end %>
+            </div>
+          </div>
+
+          <div class="absolute right-0 z-10 mt-2 w-56 origin-top-right divide-y divide-gray-100 rounded-md bg-white shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none" 
+                      role="menu" 
+                      aria-orientation="vertical" 
+                      aria-labelledby="menu-button" 
+                      tabindex="-1">
+            <div class="py-1" role="none">
+              <%= link_to profile_path, class: "flex items-center text-gray-700 block px-4 py-2 text-sm hover:bg-teal-200 transition duration-150 ease-in-out", role: "menuitem", tabindex: "-1", id: "menu-item-0" do %>
+                <span class="material-icons mr-2">manage_accounts</span>
+                <%= t('header.profile') %>
+              <% end %>
+            </div>
+            <div class="py-1" role="none">
+              <%= link_to logout_path, class: "flex items-center text-gray-700 block px-4 py-2 text-sm hover:bg-teal-200 transition duration-150 ease-in-out", role: "menuitem", tabindex: "-1", id: "menu-item-0", data: { turbo_method: :delete } do %>
+                <span class="material-icons mr-2">logout</span>
+                <%= t('header.logout') %>
+              <% end %>
+            </div>
+          </div>
         </div>
       </div>
     </div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,151 +1,16 @@
-<header class="fixed top-0 w-full z-10 bg-white" >
+<header class="fixed top-0 w-full z-10 bg-white">
   <nav class="navbar py-2 px-2 items-center shadow-lg shadow-cyan-600/70">
-    <div class="flex justify-between">
+    <div class="flex justify-between items-center w-full">
       <div class="font-bold text-3xl">
         <h1><%= link_to t('header.title'), "/" %></h1>
       </div>
-
+      
     <!-- menu -->
-      <div>
-        <!-- diagnosis menu -->
-        <div class="relative inline-block text-left">
-          <div class="flex items-center">
-            <div>
-              <button type="button" 
-                      class="inline-flex w-full justify-center gap-x-1.5 rounded-md bg-gray-200 px-3 py-2 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-teal-300" 
-                      id="diagnosis_menu-button" 
-                      aria-expanded="true" 
-                      aria-haspopup="true">
-                <div class="flex items-center">
-                  <span class="material-icons mr-1">visibility</span>
-                  <%= t('header.diagnosis') %>
-                </div>
-                <svg class="-mr-1 h-5 w-5 text-gray-400" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-                  <path fill-rule="evenodd" d="M5.23 7.21a.75.75 0 011.06.02L10 11.168l3.71-3.938a.75.75 0 111.08 1.04l-4.25 4.5a.75.75 0 01-1.08 0l-4.25-4.5a.75.75 0 01.02-1.06z" clip-rule="evenodd" />
-                </svg>
-              </button>
-            </div>
-          </div>
-
-          <div class="absolute right-0 z-10 mt-2 w-56 origin-top-right divide-y divide-gray-100 rounded-md bg-white shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none" 
-                      role="menu" 
-                      aria-orientation="vertical" 
-                      aria-labelledby="diagnosis_menu-button" 
-                      tabindex="-1">
-            <div class="py-1" role="none">
-              <%= link_to new_diagnosis_path, class: "flex items-center text-gray-700 px-4 py-2 text-sm hover:bg-teal-200 transition duration-150 ease-in-out", role: "menuitem", tabindex: "-1", id: "menu-item-0" do %>
-                <span class="material-icons mr-2">visibility</span>
-                <%= t('header.diagnosis') %>
-              <% end %>
-            </div>
-            <div class="py-1" role="none">
-              <%= link_to diagnoses_path, class: "flex items-center text-gray-700 block px-4 py-2 text-sm hover:bg-teal-200 transition duration-150 ease-in-out", role: "menuitem", tabindex: "-1", id: "menu-item-0" do %>
-                <span class="material-icons mr-2">leaderboard</span>
-                <%= t('header.diagnosis_index') %>
-              <% end %>
-            </div>
-            <div class="py-1" role="none">
-              <%= link_to favorites_diagnoses_path, class: "flex items-center text-gray-700 block px-4 py-2 text-sm hover:bg-teal-200 transition duration-150 ease-in-out", role: "menuitem", tabindex: "-1", id: "menu-item-0" do %>
-                <span class="material-icons mr-2">thumb_up_off_alt</span>
-                <%= t('header.favorite_diagnoses') %>
-              <% end %>
-            </div>
-          </div>
-        </div>
-
-        <!-- item menu -->
-        <div class="relative inline-block text-left">
-          <div class="flex items-center">
-            <div>
-              <button type="button" 
-                      class="inline-flex w-full justify-center gap-x-1.5 rounded-md bg-gray-200 px-3 py-2 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-teal-300" 
-                      id="item_menu-button" 
-                      aria-expanded="true" 
-                      aria-haspopup="true">
-                <div class="flex items-center">
-                  <span class="material-icons mr-1">savings</span>
-                  <%= t('header.item') %>
-                </div>
-                <svg class="-mr-1 h-5 w-5 text-gray-400" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-                  <path fill-rule="evenodd" d="M5.23 7.21a.75.75 0 011.06.02L10 11.168l3.71-3.938a.75.75 0 111.08 1.04l-4.25 4.5a.75.75 0 01-1.08 0l-4.25-4.5a.75.75 0 01.02-1.06z" clip-rule="evenodd" />
-                </svg>
-              </button>
-            </div>
-          </div>
-
-          <div class="absolute right-0 z-10 mt-2 w-56 origin-top-right divide-y divide-gray-100 rounded-md bg-white shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none" 
-                      role="menu" 
-                      aria-orientation="vertical" 
-                      aria-labelledby="item_menu-button" 
-                      tabindex="-1">
-            <div class="py-1" role="none">
-              <%= link_to items_path, class: "flex items-center text-gray-700 block px-4 py-2 text-sm hover:bg-teal-200 transition duration-150 ease-in-out", role: "menuitem", tabindex: "-1", id: "menu-item-0" do %>
-                <span class="material-icons mr-2">savings</span>
-                <%= t('header.item_index') %>
-              <% end %>
-            </div>
-            <div class="py-1" role="none">
-              <%= link_to items_path, class: "flex items-center text-gray-700 block px-4 py-2 text-sm hover:bg-teal-200 transition duration-150 ease-in-out", role: "menuitem", tabindex: "-1", id: "menu-item-0" do %>
-                <span class="material-icons mr-2">bookmarks</span>
-                <%= t('header.bookmark_items') %>
-              <% end %>
-            </div>
-            <div class="py-1" role="none">
-              <%= link_to new_item_path, class: "flex items-center text-gray-700 block px-4 py-2 text-sm hover:bg-teal-200 transition duration-150 ease-in-out", role: "menuitem", tabindex: "-1", id: "menu-item-0" do %>
-                <span class="material-icons mr-2">create</span>
-                <%= t('header.item_new') %>
-              <% end %>
-            </div>
-          </div>
-        </div>
-
-        <!-- profile menu -->
-        <div class="relative inline-block text-left">
-          <div class="flex items-center">
-            <div>
-              <button type="button" 
-                      class="inline-flex w-full justify-center gap-x-1.5 rounded-md bg-gray-200 px-3 py-2 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-teal-300" 
-                      id="menu-button" 
-                      aria-expanded="true" 
-                      aria-haspopup="true">
-                <div class="flex items-center">
-                  <span class="material-icons">manage_accounts</span>
-                  <%= t('header.profile') %>
-                </div>
-                <svg class="-mr-1 h-5 w-5 text-gray-400" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-                  <path fill-rule="evenodd" d="M5.23 7.21a.75.75 0 011.06.02L10 11.168l3.71-3.938a.75.75 0 111.08 1.04l-4.25 4.5a.75.75 0 01-1.08 0l-4.25-4.5a.75.75 0 01.02-1.06z" clip-rule="evenodd" />
-                </svg>
-              </button>
-            </div>
-
-            <div class="ml-2">
-              <% if current_user.google_avatar_image.blank? %>
-                <%= image_tag current_user.avatar_image_url, class: "h-10 w-10 object-cove rounded-full object-cover" %>
-              <% else %>
-                <%= image_tag current_user.google_avatar_image, class: "h-10 w-10 object-cove rounded-full object-cover" %>
-              <% end %>
-            </div>
-          </div>
-
-          <div class="absolute right-0 z-10 mt-2 w-56 origin-top-right divide-y divide-gray-100 rounded-md bg-white shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none" 
-                      role="menu" 
-                      aria-orientation="vertical" 
-                      aria-labelledby="menu-button" 
-                      tabindex="-1">
-            <div class="py-1" role="none">
-              <%= link_to profile_path, class: "flex items-center text-gray-700 block px-4 py-2 text-sm hover:bg-teal-200 transition duration-150 ease-in-out", role: "menuitem", tabindex: "-1", id: "menu-item-0" do %>
-                <span class="material-icons mr-2">manage_accounts</span>
-                <%= t('header.profile') %>
-              <% end %>
-            </div>
-            <div class="py-1" role="none">
-              <%= link_to logout_path, class: "flex items-center text-gray-700 block px-4 py-2 text-sm hover:bg-teal-200 transition duration-150 ease-in-out", role: "menuitem", tabindex: "-1", id: "menu-item-0", data: { turbo_method: :delete } do %>
-                <span class="material-icons mr-2">logout</span>
-                <%= t('header.logout') %>
-              <% end %>
-            </div>
-          </div>
-        </div>
+      <div class="hidden md:flex">
+        <%= render "shared/large_screen_menu" %>
+      </div>
+      <div class="flex md:hidden">
+        <%= render "shared/small_screen_menu" %>
       </div>
     </div>
   </nav>

--- a/app/views/shared/_large_screen_menu.html.erb
+++ b/app/views/shared/_large_screen_menu.html.erb
@@ -1,0 +1,130 @@
+<!-- diagnosis menu -->
+<div class="relative inline-block text-left mr-2">
+    <div class="flex items-center">
+        <button type="button" 
+                class="inline-flex w-full justify-center gap-x-1.5 rounded-md bg-gray-200 px-3 py-2 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-teal-300" 
+                id="diagnosis_menu-button" 
+                aria-expanded="true" 
+                aria-haspopup="true">
+            <div class="flex items-center">
+                <span class="material-icons mr-1">visibility</span>
+                <%= t('header.diagnosis') %>
+            </div>
+            <svg class="-mr-1 h-5 w-5 text-gray-400" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+                <path fill-rule="evenodd" d="M5.23 7.21a.75.75 0 011.06.02L10 11.168l3.71-3.938a.75.75 0 111.08 1.04l-4.25 4.5a.75.75 0 01-1.08 0l-4.25-4.5a.75.75 0 01.02-1.06z" clip-rule="evenodd" />
+            </svg>
+        </button>
+    </div>
+    <div class="absolute right-0 z-10 mt-2 w-56 origin-top-right divide-y divide-gray-100 rounded-md bg-white shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none" 
+                role="menu" 
+                aria-orientation="vertical" 
+                aria-labelledby="diagnosis_menu-button" 
+                tabindex="-1">
+        <div class="py-1" role="none">
+            <%= link_to new_diagnosis_path, class: "flex items-center text-gray-700 px-4 py-2 text-sm hover:bg-teal-200 transition duration-150 ease-in-out", role: "menuitem", tabindex: "-1", id: "menu-item-0" do %>
+                <span class="material-icons mr-2">visibility</span>
+                <%= t('header.diagnosis') %>
+            <% end %>
+        </div>
+        <div class="py-1" role="none">
+            <%= link_to diagnoses_path, class: "flex items-center text-gray-700 block px-4 py-2 text-sm hover:bg-teal-200 transition duration-150 ease-in-out", role: "menuitem", tabindex: "-1", id: "menu-item-0" do %>
+                <span class="material-icons mr-2">leaderboard</span>
+                <%= t('header.diagnosis_index') %>
+            <% end %>
+        </div>
+        <div class="py-1" role="none">
+            <%= link_to favorites_diagnoses_path, class: "flex items-center text-gray-700 block px-4 py-2 text-sm hover:bg-teal-200 transition duration-150 ease-in-out", role: "menuitem", tabindex: "-1", id: "menu-item-0" do %>
+                <span class="material-icons mr-2">thumb_up_off_alt</span>
+                <%= t('header.favorite_diagnoses') %>
+            <% end %>
+        </div>
+    </div>
+    </div>
+
+    <!-- item menu -->
+    <div class="relative inline-block text-left mr-2">
+        <div class="flex items-center">
+            <button type="button" 
+                    class="inline-flex w-full justify-center gap-x-1.5 rounded-md bg-gray-200 px-3 py-2 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-teal-300" 
+                    id="item_menu-button" 
+                    aria-expanded="true" 
+                    aria-haspopup="true">
+                <div class="flex items-center">
+                    <span class="material-icons mr-1">savings</span>
+                    <%= t('header.item') %>
+                </div>
+                <svg class="-mr-1 h-5 w-5 text-gray-400" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+                    <path fill-rule="evenodd" d="M5.23 7.21a.75.75 0 011.06.02L10 11.168l3.71-3.938a.75.75 0 111.08 1.04l-4.25 4.5a.75.75 0 01-1.08 0l-4.25-4.5a.75.75 0 01.02-1.06z" clip-rule="evenodd" />
+                </svg>
+            </button>
+        </div>
+        <div class="absolute right-0 z-10 mt-2 w-56 origin-top-right divide-y divide-gray-100 rounded-md bg-white shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none" 
+                    role="menu" 
+                    aria-orientation="vertical" 
+                    aria-labelledby="item_menu-button" 
+                    tabindex="-1">
+            <div class="py-1" role="none">
+                <%= link_to items_path, class: "flex items-center text-gray-700 block px-4 py-2 text-sm hover:bg-teal-200 transition duration-150 ease-in-out", role: "menuitem", tabindex: "-1", id: "menu-item-0" do %>
+                    <span class="material-icons mr-2">savings</span>
+                    <%= t('header.item_index') %>
+                <% end %>
+            </div>
+            <div class="py-1" role="none">
+                <%= link_to items_path, class: "flex items-center text-gray-700 block px-4 py-2 text-sm hover:bg-teal-200 transition duration-150 ease-in-out", role: "menuitem", tabindex: "-1", id: "menu-item-0" do %>
+                    <span class="material-icons mr-2">bookmarks</span>
+                    <%= t('header.bookmark_items') %>
+                <% end %>
+            </div>
+            <div class="py-1" role="none">
+                <%= link_to new_item_path, class: "flex items-center text-gray-700 block px-4 py-2 text-sm hover:bg-teal-200 transition duration-150 ease-in-out", role: "menuitem", tabindex: "-1", id: "menu-item-0" do %>
+                    <span class="material-icons mr-2">create</span>
+                    <%= t('header.item_new') %>
+                <% end %>
+            </div>
+        </div>
+    </div>
+
+    <!-- profile menu -->
+    <div class="relative inline-block text-left mr-2">
+        <div class="flex items-center">
+            <button type="button" 
+                    class="inline-flex w-full justify-center gap-x-1.5 rounded-md bg-gray-200 px-3 py-2 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-teal-300" 
+                    id="menu-button" 
+                    aria-expanded="true" 
+                    aria-haspopup="true">
+                <div class="flex items-center">
+                    <span class="material-icons">manage_accounts</span>
+                    <%= t('header.profile') %>
+                </div>
+                <svg class="-mr-1 h-5 w-5 text-gray-400" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+                    <path fill-rule="evenodd" d="M5.23 7.21a.75.75 0 011.06.02L10 11.168l3.71-3.938a.75.75 0 111.08 1.04l-4.25 4.5a.75.75 0 01-1.08 0l-4.25-4.5a.75.75 0 01.02-1.06z" clip-rule="evenodd" />
+                </svg>
+            </button>
+        </div>
+        <div class="absolute right-0 z-10 mt-2 w-56 origin-top-right divide-y divide-gray-100 rounded-md bg-white shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none" 
+                    role="menu" 
+                    aria-orientation="vertical" 
+                    aria-labelledby="menu-button" 
+                    tabindex="-1">
+            <div class="py-1" role="none">
+                <%= link_to profile_path, class: "flex items-center text-gray-700 block px-4 py-2 text-sm hover:bg-teal-200 transition duration-150 ease-in-out", role: "menuitem", tabindex: "-1", id: "menu-item-0" do %>
+                    <span class="material-icons mr-2">manage_accounts</span>
+                    <%= t('header.profile') %>
+                    <div class="ml-5">
+                        <% if current_user.google_avatar_image.blank? %>
+                            <%= image_tag current_user.avatar_image_url, class: "h-10 w-10 object-cove rounded-full object-cover" %>
+                        <% else %>
+                            <%= image_tag current_user.google_avatar_image, class: "h-10 w-10 object-cove rounded-full object-cover" %>
+                        <% end %>
+                    </div>
+                <% end %>
+            </div>
+            <div class="py-1" role="none">
+                <%= link_to logout_path, class: "flex items-center text-gray-700 block px-4 py-2 text-sm hover:bg-teal-200 transition duration-150 ease-in-out", role: "menuitem", tabindex: "-1", id: "menu-item-0", data: { turbo_method: :delete } do %>
+                    <span class="material-icons mr-2">logout</span>
+                    <%= t('header.logout') %>
+                <% end %>
+            </div>
+        </div>
+    </div>
+</div>

--- a/app/views/shared/_small_screen_menu.html.erb
+++ b/app/views/shared/_small_screen_menu.html.erb
@@ -1,0 +1,79 @@
+<!-- diagnosis menu -->
+<div class="relative inline-block text-left mr-2">
+    <div class="flex items-center">
+        <button type="button" 
+                class="inline-flex w-full justify-center gap-x-1.5 rounded-md bg-gray-200 px-3 py-2 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-teal-300" 
+                id="small_menu-button" 
+                aria-expanded="true" 
+                aria-haspopup="true">
+            <div class="flex items-center">
+                <span class="material-icons">list</span>
+                <%= t('header.menu') %>
+            </div>
+            <svg class="-mr-1 h-5 w-5 text-gray-400" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+                <path fill-rule="evenodd" d="M5.23 7.21a.75.75 0 011.06.02L10 11.168l3.71-3.938a.75.75 0 111.08 1.04l-4.25 4.5a.75.75 0 01-1.08 0l-4.25-4.5a.75.75 0 01.02-1.06z" clip-rule="evenodd" />
+            </svg>
+        </button>
+    </div>
+    <div class="absolute right-0 z-10 mt-2 w-56 origin-top-right divide-y divide-gray-100 rounded-md bg-white shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none" 
+                role="menu" 
+                aria-orientation="vertical" 
+                aria-labelledby="small_menu-button" 
+                tabindex="-1">
+    <div class="py-1" role="none">
+        <%= link_to new_diagnosis_path, class: "flex items-center text-gray-700 px-4 py-2 text-sm hover:bg-teal-200 transition duration-150 ease-in-out", role: "menuitem", tabindex: "-1", id: "menu-item-0" do %>
+            <span class="material-icons mr-2">visibility</span>
+            <%= t('header.diagnosis') %>
+        <% end %>
+    </div>
+    <div class="py-1" role="none">
+        <%= link_to diagnoses_path, class: "flex items-center text-gray-700 block px-4 py-2 text-sm hover:bg-teal-200 transition duration-150 ease-in-out", role: "menuitem", tabindex: "-1", id: "menu-item-0" do %>
+            <span class="material-icons mr-2">leaderboard</span>
+            <%= t('header.diagnosis_index') %>
+        <% end %>
+    </div>
+    <div class="py-1" role="none">
+        <%= link_to favorites_diagnoses_path, class: "flex items-center text-gray-700 block px-4 py-2 text-sm hover:bg-teal-200 transition duration-150 ease-in-out", role: "menuitem", tabindex: "-1", id: "menu-item-0" do %>
+            <span class="material-icons mr-2">thumb_up_off_alt</span>
+            <%= t('header.favorite_diagnoses') %>
+        <% end %>
+    </div>
+        <div class="py-1" role="none">
+            <%= link_to items_path, class: "flex items-center text-gray-700 block px-4 py-2 text-sm hover:bg-teal-200 transition duration-150 ease-in-out", role: "menuitem", tabindex: "-1", id: "menu-item-0" do %>
+                <span class="material-icons mr-2">savings</span>
+                <%= t('header.item_index') %>
+            <% end %>
+        </div>
+        <div class="py-1" role="none">
+            <%= link_to items_path, class: "flex items-center text-gray-700 block px-4 py-2 text-sm hover:bg-teal-200 transition duration-150 ease-in-out", role: "menuitem", tabindex: "-1", id: "menu-item-0" do %>
+                <span class="material-icons mr-2">bookmarks</span>
+                <%= t('header.bookmark_items') %>
+            <% end %>
+        </div>
+        <div class="py-1" role="none">
+            <%= link_to new_item_path, class: "flex items-center text-gray-700 block px-4 py-2 text-sm hover:bg-teal-200 transition duration-150 ease-in-out", role: "menuitem", tabindex: "-1", id: "menu-item-0" do %>
+                <span class="material-icons mr-2">create</span>
+                <%= t('header.item_new') %>
+            <% end %>
+        </div>
+        <div class="py-1" role="none">
+            <%= link_to profile_path, class: "flex items-center text-gray-700 block px-4 py-2 text-sm hover:bg-teal-200 transition duration-150 ease-in-out", role: "menuitem", tabindex: "-1", id: "menu-item-0" do %>
+                <span class="material-icons mr-2">manage_accounts</span>
+                <%= t('header.profile') %>
+                <div class="ml-5">
+                    <% if current_user.google_avatar_image.blank? %>
+                        <%= image_tag current_user.avatar_image_url, class: "h-10 w-10 object-cove rounded-full object-cover" %>
+                    <% else %>
+                        <%= image_tag current_user.google_avatar_image, class: "h-10 w-10 object-cove rounded-full object-cover" %>
+                    <% end %>
+                </div>
+            <% end %>
+        </div>
+        <div class="py-1" role="none">
+            <%= link_to logout_path, class: "flex items-center text-gray-700 block px-4 py-2 text-sm hover:bg-teal-200 transition duration-150 ease-in-out", role: "menuitem", tabindex: "-1", id: "menu-item-0", data: { turbo_method: :delete } do %>
+                <span class="material-icons mr-2">logout</span>
+                <%= t('header.logout') %>
+            <% end %>
+        </div>
+    </div>
+</div>

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -24,6 +24,7 @@ ja:
     item_new_before_login: アイテム登録 (ログイン必要）
     favorite_diagnoses: お気に入り一覧
     profile: プロフィール
+    menu: メニュー
   
   footer:
     title: デスク色彩診断

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -15,8 +15,13 @@ ja:
     login: ログイン
     logout: ログアウト
     diagnosis_index: 診断一覧
-    diagnosis: 診断
+    diagnosis: デスク診断
+    item: デスクアイテム
+    item_index: デスクアイテム一覧
+    item_new: アイテム登録
+    bookmark_items: ブックマークアイテム
     diagnosis_before_login: 診断 (ログイン必要）
+    item_new_before_login: アイテム登録 (ログイン必要）
     favorite_diagnoses: お気に入り一覧
     profile: プロフィール
   


### PR DESCRIPTION
#161 

# 概要
item関連のヘッダー作成。
ヘッダーを診断・アイテム・プロフィールの３つに分ける。