### PR TITLE
OpenAIへのプロンプト修正

### DIFF
--- a/app/controllers/diagnoses_controller.rb
+++ b/app/controllers/diagnoses_controller.rb
@@ -31,6 +31,7 @@ class DiagnosesController < ApplicationController
     if uploaded_image_path.present?
       analysis_result = GoogleCloudVisionApi.analyze_image(uploaded_image_path)
       @diagnosis.color_info = analysis_result
+      # この部分も修正して楽天APIに送る
       @diagnosis.color_name = RakutenApi.color_name(analysis_result)
     end
 
@@ -40,7 +41,11 @@ class DiagnosesController < ApplicationController
     end
 
     if @diagnosis.result_en.present?
+      # 診断結果翻訳
       translated_response = DeeplApi.translate(@diagnosis.result_en, 'JA')
+      # 診断結果から色名を抽出
+      color_name = translated_response.slice(/「(.*?)」/, 1)
+      # 診断結果全文
       @diagnosis.result_jp = translated_response
     end
 

--- a/app/models/diagnosis.rb
+++ b/app/models/diagnosis.rb
@@ -4,7 +4,7 @@ class Diagnosis < ApplicationRecord
     validate :desk_image_must_not_be_default
     validates :place_id, presence: true
     validates :desk_work, presence: true, length: { maximum: 255 }
-    validate :user_diagnosis_limit, on: :create
+    # validate :user_diagnosis_limit, on: :create
 
     belongs_to :user
     belongs_to :place

--- a/app/services/open_ai_api.rb
+++ b/app/services/open_ai_api.rb
@@ -15,12 +15,13 @@ class OpenAiApi
 
                     # Conditions
                     Output is always less than 250 tokens.
-                    No numerical RGB values are output(output with specific color names[red, blue, green, yellow, orange, purple, brown, white, black, gray, yellowish green, and light blue]is acceptable).
+                    No numerical RGB values are output(output with specific color names[red, blue, green, yellow, orange, purple, brown, white, black, gray, yellowish green, and light blue, etc]is acceptable).
                     Color dominance of the desk environment diagnosed: #{color_info}.
+                    Select only one color to be incorporated from the #{Color.pluck(:name)} and surround it with 【 】 to output.
 
                     # Output the following in one sentence in a gentle tone.
                     ・What are the good and bad points of the current desk environment for human work?
-                    ・Please suggest improvements to further improve the work efficiency of #{desk_work} in terms of color.
+                    ・Please suggest improvements in terms of color to further improve the work efficiency of #{desk_work}.
                     ・Please add a few words at the end to say that you hope the work efficiency will improve."
                 }
                 ]


### PR DESCRIPTION
#187 

# 概要
OpenAIへのプロンプト修正。
取り入れるべき色名をColorsテーブルのnameカラムから１つ選んで【】で囲って出力するよう設定。
- app/services/open_ai_api.rb
```ruby
class OpenAiApi
    def self.chat(color_info, desk_work, desk_place)
        @client = OpenAI::Client.new(access_token: ENV['OPENAI_API_KEY'])
        @client.chat(
            parameters: {
                model: "gpt-4",
                max_tokens: 250,
                messages: [
                {
                    role: "system", content: "You are a professional who diagnoses desk environments in terms of how color affects human desk work."
                },
                {
                    role: "user", content: 
                    "Please provide diagnostic results of your desk environment under the following conditions

                    # Conditions
                    Output is always less than 250 tokens.
                    No numerical RGB values are output(output with specific color names[red, blue, green, yellow, orange, purple, brown, white, black, gray, yellowish green, and light blue, etc]is acceptable).
                    Color dominance of the desk environment diagnosed: #{color_info}.
                    Select only one color to be incorporated from the #{Color.pluck(:name)} and surround it with 【 】 to output.

                    # Output the following in one sentence in a gentle tone.
                    ・What are the good and bad points of the current desk environment for human work?
                    ・Please suggest improvements in terms of color to further improve the work efficiency of #{desk_work}.
                    ・Please add a few words at the end to say that you hope the work efficiency will improve."
                }
                ]
            }
        )
    end
end

```