### PR TITLE
楽天APIに診断結果の色名を渡す

### DIFF
--- a/app/controllers/diagnoses_controller.rb
+++ b/app/controllers/diagnoses_controller.rb
@@ -31,8 +31,7 @@ class DiagnosesController < ApplicationController
     if uploaded_image_path.present?
       analysis_result = GoogleCloudVisionApi.analyze_image(uploaded_image_path)
       @diagnosis.color_info = analysis_result
-      # この部分も修正して楽天APIに送る
-      @diagnosis.color_name = RakutenApi.color_name(analysis_result)
+      # @diagnosis.color_name = RakutenApi.color_name(analysis_result)
     end
 
     if @diagnosis.color_info.present? && @diagnosis.place_id.present?
@@ -43,8 +42,8 @@ class DiagnosesController < ApplicationController
     if @diagnosis.result_en.present?
       # 診断結果翻訳
       translated_response = DeeplApi.translate(@diagnosis.result_en, 'JA')
-      # 診断結果から色名を抽出
-      color_name = translated_response.slice(/「(.*?)」/, 1)
+      # 診断結果からデスク環境に取り入れるべき色名を抽出
+      @diagnosis.color_name = translated_response.slice(/【(.*?)】/, 1)
       # 診断結果全文
       @diagnosis.result_jp = translated_response
     end

--- a/app/views/diagnoses/show.html.erb
+++ b/app/views/diagnoses/show.html.erb
@@ -9,7 +9,7 @@
     </div>
 
     <div class="mb-3 flex flex-col">
-      <h1 class= "font-bold mb-1 text-2xl sm:text-3xl md:text-4xl"><%= t('.result') %></h1>
+      <h1 class= "font-bold mb-1 text-2xl sm:text-2xl md:text-3xl"><%= t('.result') %></h1>
         <div class="font-bold container p-4 m-2 shadow-lg shadow-stone-800/90 bg-stone-100 rounded-md border-2 border-stone-500">
           <%= @diagnosis.result_jp %>
         </div>
@@ -30,14 +30,17 @@
 
     <hr class="border-2 bg-black my-4">
 
-    <!-- 楽天商品提案 -->
+    <!-- 商品提案 -->
     <div class="mt-5 mb-3 text-center">
-      <h1 class= "font-bold mb-1 text-2xl sm:text-3xl md:text-4xl"><%= t('.recommend') %></h1> 
+      <h1 class= "font-bold mb-1 text-1xl sm:text-2xl md:text-3xl"><%= t('.recommend') %></h1> 
+      <!-- 楽天商品提案 -->
       <% if @diagnosis.color_name.present? %>
         <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
-          <% items = RakutenWebService::Ichiba::Item.search(keyword: "オブジェ #{@diagnosis.color_name}", hits: 9) %>
+          <% items = RakutenWebService::Ichiba::Item.search(keyword: "北欧 インテリア #{@diagnosis.color_name}", 
+                                                            NGKeyword: "風水 鏡 車 内装 生地 エアコン ピクニック キッチン シフト ペット 玄関 ソファー カーペット ラグ クッション", 
+                                                            hits: 9) %>
             <% items.each do |item| %>
-              <div class="container max-w-sm p-4 m-2 shadow-lg shadow-stone-800/80 bg-stone-100 hover:bg-emerald-200 rounded-md transition duration-300">
+              <div class="container max-w-sm p-2 m-2 shadow-lg shadow-stone-800/80 bg-stone-100 hover:bg-emerald-200 rounded-md transition duration-300">
                 <div class="flex justify-center mb-4">
                   <%= image_tag item['mediumImageUrls'].first %><br>
                 </div>

--- a/app/views/kaminari/diagnoses/_gap.html.erb
+++ b/app/views/kaminari/diagnoses/_gap.html.erb
@@ -1,2 +1,2 @@
 <!-- ページ番号間の... -->
-<span class="page gap w-8 h-8 bg-white border text-center text-red-500"><%= t('views.pagination.truncate').html_safe %></span>
+<%# <span class="page gap w-8 h-8 bg-white border text-center text-red-500"><%= t('views.pagination.truncate').html_safe ></#span> %>


### PR DESCRIPTION
#189 

# 概要
楽天APIに診断結果の色名を渡す。

- [x] 診断結果から抽出したデスク環境に取り入れるべき色名を@diagnosis.color_nameに代入

app/controllers/diagnoses_controller.rb
```ruby
    if @diagnosis.result_en.present?
      # 診断結果翻訳
      translated_response = DeeplApi.translate(@diagnosis.result_en, 'JA')
      # 診断結果からデスク環境に取り入れるべき色名を抽出
      @diagnosis.color_name = translated_response.slice(/【(.*?)】/, 1)
      # 診断結果全文
      @diagnosis.result_jp = translated_response
    end
```

- [x] 詳細画面で楽天商品検索APIに検索ワードとして@diagnosis.color_nameを渡す。
- [x] 検索結果の精度を上げるためNGキーワードのオプション追加。
app/views/diagnoses/show.html.erb
```ruby
    <!-- 商品提案 -->
    <div class="mt-5 mb-3 text-center">
      <h1 class= "font-bold mb-1 text-1xl sm:text-2xl md:text-3xl"><%= t('.recommend') %></h1> 
      <!-- 楽天商品提案 -->
      <% if @diagnosis.color_name.present? %>
        <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
          <% items = RakutenWebService::Ichiba::Item.search(keyword: "北欧 インテリア #{@diagnosis.color_name}", 
                                                            NGKeyword: "風水 鏡 車 内装 生地 エアコン ピクニック キッチン シフト ペット 玄関 ソファー カーペット ラグ クッション", 
                                                            hits: 9) %>
            <% items.each do |item| %>
              <div class="container max-w-sm p-2 m-2 shadow-lg shadow-stone-800/80 bg-stone-100 hover:bg-emerald-200 rounded-md transition duration-300">
                <div class="flex justify-center mb-4">
                  <%= image_tag item['mediumImageUrls'].first %><br>
                </div>
                <%= link_to item['itemName'], item.url, target: '_blank' %><br>
                <%= "#{item['itemPrice']}円 " %><br>
              </div>
            <% end %>
        </div>
      <% end %>
    </div>
```