### PR TITLE
itemフォームで色を３つまでしか選択できないよう制限追加

### DIFF
--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -2,6 +2,7 @@ class Item < ApplicationRecord
   mount_uploader :item_image, ItemImageUploader
 
   validate :item_image_must_not_be_default
+  validate :validate_color_selection
   validates :title, presence: true, length: { maximum: 255 }
   validates :color_ids, presence: true
   validates :body, presence: true, length: { maximum: 255 }
@@ -15,6 +16,12 @@ class Item < ApplicationRecord
   def item_image_must_not_be_default
     if item_image.default_image?
         errors.add(:item_image, "を選択してください。")
+    end
+  end
+
+  def validate_color_selection
+    if color_ids.count > 3
+      errors.add(:color_ids, "は3つまでしか選択できません。")
     end
   end
 


### PR DESCRIPTION
#190 

# 概要
itemフォームで色を３つまでしか選択できないよう制限追加
itemsモデルにカスタムバリデーション追加
```ruby 
class Item < ApplicationRecord

  validate :validate_color_selection

  def validate_color_selection
    if color_ids.count > 3
      errors.add(:color_ids, "は3つまでしか選択できません。")
    end
  end

end
```
[![Image from Gyazo](https://i.gyazo.com/36e79587ee866d62c7a8ff4e3d483be7.png)](https://gyazo.com/36e79587ee866d62c7a8ff4e3d483be7)