### PR TITLE
jsファイルの挙動修正

### DIFF
--- a/app/javascript/menu.js
+++ b/app/javascript/menu.js
@@ -1,4 +1,8 @@
-document.addEventListener('turbo:load', (event) => {
+document.addEventListener('turbo:load', setupMenus);
+document.addEventListener('turbo:render', setupMenus);
+
+// setupMenus関数を作成
+function setupMenus() {
     const menuButton = document.getElementById('menu-button');
     const diagnosisMenuButton = document.getElementById('diagnosis_menu-button');
     const itemMenuButton = document.getElementById('item_menu-button');
@@ -12,7 +16,7 @@ document.addEventListener('turbo:load', (event) => {
     const toggleMenu = (button, menu) => {
         if (button && menu) {
             let isOpen = false;
-            menu.style.display = 'none'; // これを追加
+            menu.style.display = 'none';
 
             const openMenu = () => {
                 isOpen = true;
@@ -44,4 +48,4 @@ document.addEventListener('turbo:load', (event) => {
     toggleMenu(diagnosisMenuButton, diagnosisMenu);
     toggleMenu(itemMenuButton, itemMenu);
     toggleMenu(smallMenuButton, smallMenu);
-});
+}

--- a/app/javascript/previews.js
+++ b/app/javascript/previews.js
@@ -1,47 +1,40 @@
-// 画像ファイルを選択した際にその画像をプレビュー表示。
+document.addEventListener('turbo:load', setupImagePreview);
+document.addEventListener('turbo:render', setupImagePreview);
 
-// 第一引数：イベント名。第二引数；イベント発生時に実行する関数。
-document.addEventListener('turbo:load', (event) => {
-  // id=desk_imageの要素が存在する場合、input変数に格納しchangeイベントリスナーを追加。
+// setupImagePreview関数を作成
+function setupImagePreview() {
   const deskInput = document.querySelector('#desk_image');
-  // id=avatar_imageの要素が存在する場合、input変数に格納しchangeイベントリスナーを追加。
   const avatarInput = document.querySelector('#avatar_image');
-  // id=item_imageの要素が存在する場合、input変数に格納しchangeイベントリスナーを追加。
   const itemInput = document.querySelector('#item_image');
 
-  // ユーザーが新しい画像を選択するたびにpreviewImage関数を呼す。(第一引数：イベント名。第二引数；イベント発生時に実行する関数。)
   if (deskInput) {
+    deskInput.removeEventListener('change', previewImage);
     deskInput.addEventListener('change', previewImage);
   }
 
   if (avatarInput) {
+    avatarInput.removeEventListener('change', previewImage);
     avatarInput.addEventListener('change', previewImage);
   }
 
   if (itemInput) {
+    itemInput.removeEventListener('change', previewImage);
     itemInput.addEventListener('change', previewImage);
   }
-});
+}
 
-// previewImage関数を定義。ユーザーが新しい画像を選択するたびに呼び出される。
 function previewImage(event) {
-  // イベントが発生した要素（この場合<input要素>をtarget定数に格納。
   const target = event.target;
-  // 選択されたファイル（<input>要素のfiles配列の最初の要素）をfileという定数に格納。
   const file = target.files[0];
-  // 新しいFileReaderオブジェクトを作成し、readerという定数に格納。このFileReaderオブジェクトは、ファイルのデータを読み込むために使用される。
   const reader = new FileReader();
 
-  // FileReaderオブジェクトのonloadendプロパティを、新しい関数に設定。この関数はFileReaderがファイルの読み込みを終了したときに呼び出される。
   reader.onloadend = function () {
     const preview = document.querySelector("#preview");
-    // preview要素が存在する場合、そのsrc属性をFileReaderの結果（読み込んだファイルのデータURL）に設定。これにより、選択された画像のプレビューが表示される。
     if (preview) {
       preview.src = reader.result;
     }
   }
 
-  // 選択されたファイルが存在する場合、FileReaderにそのファイルをデータURLとして読み込むように指示。これにより、reader.onloadend関数が呼び出され、プレビューが表示される。
   if (file) {
     reader.readAsDataURL(file);
   }

--- a/app/javascript/select_place.js
+++ b/app/javascript/select_place.js
@@ -1,20 +1,25 @@
-document.addEventListener('turbo:load', (event) => {
-    document.querySelector('#category_select').addEventListener('change', (event) => {
-        let value = event.target.value;
-        if (value == '1') { // オフィス
-            document.querySelector('#office').style.display = 'block';
-            document.querySelector('#office select').disabled = false;
-            document.querySelector('#home').style.display = 'none';
-            document.querySelector('#home select').disabled = true;
-        } else if (value == '2') { // 在宅
-            document.querySelector('#office').style.display = 'none';
-            document.querySelector('#office select').disabled = true;
-            document.querySelector('#home').style.display = 'block';
-            document.querySelector('#home select').disabled = false;
-        }
-    });
-});
+document.addEventListener('turbo:load', setupCategorySelect);
+document.addEventListener('turbo:render', setupCategorySelect);
 
-// category_selectの選択が変更されたときに、
-// 選択されていないフォームのselect要素を無効にし（disabled = true）
-// 選択されたフォームのselect要素を有効にする（disabled = false）
+// setupCategorySelect関数を作成
+function setupCategorySelect() {
+    const categorySelect = document.querySelector('#category_select');
+    if (categorySelect) {
+    categorySelect.addEventListener('change', (event) => {
+        let value = event.target.value;
+        const office = document.querySelector('#office');
+        const home = document.querySelector('#home');
+      if (value == '1') { // オフィス
+        office.style.display = 'block';
+        office.querySelector('select').disabled = false;
+        home.style.display = 'none';
+        home.querySelector('select').disabled = true;
+      } else if (value == '2') { // 在宅
+        office.style.display = 'none';
+        office.querySelector('select').disabled = true;
+        home.style.display = 'block';
+        home.querySelector('select').disabled = false;
+        }
+        });
+    }
+}

--- a/app/models/diagnosis.rb
+++ b/app/models/diagnosis.rb
@@ -4,7 +4,7 @@ class Diagnosis < ApplicationRecord
     validate :desk_image_must_not_be_default
     validates :place_id, presence: true
     validates :desk_work, presence: true, length: { maximum: 255 }
-    # validate :user_diagnosis_limit, on: :create
+    validate :user_diagnosis_limit, on: :create
 
     belongs_to :user
     belongs_to :place

--- a/app/models/place.rb
+++ b/app/models/place.rb
@@ -2,6 +2,8 @@ class Place < ApplicationRecord
     belongs_to :category
     has_many :diagnoses, dependent: :destroy
 
+    validates :category_id, presence: true
+
     # 検索条件で使えるカラムを指定
     def self.ransackable_attributes(auth_object = nil)
         %w[category_id]

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -10,7 +10,7 @@
     <%= render "search_form", q: @q, url: items_path %>
   </div>
 
-  <hr class="border-1 bg-stone-400 my-4">
+  <hr class="border border-stone-300 my-4">
 
   <!-- 診断一覧 -->
   <div class="mb-2">

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -26,7 +26,7 @@
     </div>
 
     <!-- 色 -->
-    <div class="mt-2 font-bold">
+    <div class="mb-3 font-bold">
       <h1 class= "font-bold mb-1 text-1xl sm:text-2xl"><%= t('.color') %></h1>
       <div class="flex justify-center">
         <% @item.colors.each do |color| %>
@@ -41,18 +41,17 @@
     <div class="mb-3 flex flex-col">
       <h1 class= "font-bold mb-1 text-1xl sm:text-2xl"><%= t('.url') %></h1>
         <div class="font-bold container p-4 m-2 shadow-lg shadow-stone-800/90 bg-white rounded-md border border-stone-500">
-          <%= link_to t('items.item.url'), "#{@item.item_url}" %>
+          <% if @item.item_url.present? %>
+            <div class="underline underline-offset-2">
+              <%= link_to "#{@item.item_url}", "#{@item.item_url}" %>
+            </div>
+          <% else %>
+            <%= t('.no_url') %>
+          <% end%>
         </div>
     </div>
 
-    <!-- Xにシェア -->
     <div class="flex items-center justify-center">
-      <div class="mb-3 inline-block bg-emerald-100 hover:bg-emerald-300 font-bold mx-1 py-2 px-4 rounded transition duration-150 ease-in-out border border-black">
-        <%= link_to "#", target: '_blank', class: "flex justify-center items-center", data: { toggle: "tooltip", placement: "bottom" } do %>
-          <%= image_tag 'X-logo-black.png', class: "h-6 w-6 object-cove rounded-md mr-2 p-1 bg-slate-300 border border-black"%>
-          <%= t('.sns_share') %>
-        <% end %>
-      </div>
       <div class="mb-3">
         <%= link_to t('.item_index'), items_path, class: "inline-block bg-emerald-100 hover:bg-emerald-300 font-bold mx-1 py-2 px-4 rounded transition duration-150 ease-in-out border border-black"%>
       </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -31,6 +31,7 @@
         <%= render "shared/flash_message" %>
         <%= yield %>
       </div>
+        <hr class="border border-stone-300 my-2">
         <%= render "shared/footer" %>
     </div>
   </body>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -2,7 +2,7 @@
   <div class="flex justify-center">
     <ul>
       <li class="flex items-center">
-        <h1 class="font-bold text-2xl px-4"><%= t('footer.title') %></h1>
+        <h1 class="font-bold text-1xl sm:text-2xl px-4 "><%= t('footer.title') %></h1>
         <p>Copyright © デスク色彩診断</P>
       </li>
       <li class="flex justify-center items-center">

--- a/app/views/shared/large_screen/_after_login_menu.html.erb
+++ b/app/views/shared/large_screen/_after_login_menu.html.erb
@@ -1,5 +1,5 @@
-<!-- diagnosis menu -->
 <div class="relative inline-block text-left mr-2">
+    <!-- diagnosis menu -->
     <div class="flex items-center">
         <button type="button" 
                 class="inline-flex w-full justify-center gap-x-1.5 rounded-md bg-gray-200 px-3 mt-1 py-1 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-teal-300" 

--- a/config/locales/activerecord.ja.yml
+++ b/config/locales/activerecord.ja.yml
@@ -3,6 +3,7 @@ ja:
     models:
       user: ユーザー
       diagnosis: 診断
+      place: デスク環境
       profile: プロフィール
       item: 商品
       item_category: 商品カテゴリー
@@ -23,6 +24,8 @@ ja:
         desk_image: デスク写真
         desk_work: デスクでの主な作業内容
         tag_ids: デスク作業場
+        place_id: 作業区分
+        place: デスク配置
       item:
         title: タイトル
         body: 商品説明

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -128,6 +128,7 @@ ja:
       body: 商品説明
       color: 色分類
       url: 商品購入先URL
+      no_url: ※ 未設定です
       sns_share: シェア
       diagnosis_index: デスク診断一覧
       item_index: 登録商品一覧


### PR DESCRIPTION
#182 

# 概要
画面リロード or バリデーション時にjsが上手く機能しないのを修正

- [x]  画面リロード時にトグルが一瞬開くのを修正
- [x]  診断または商品登録時にバリデーション引っ掛かった際にトグルが全て開くのを修正
- [x]  診断または商品登録時にバリデーション引っ掛かった際デスク環境のセレクトボックスが表示されないのを修正
- [x]  診断または商品登録時にバリデーション引っ掛かった際プレビュー表示されないのを修正

以下のように'turbo:load'と'turbo:render'イベントが発火した時に関数を呼ぶように修正した。
```javascript
document.addEventListener('turbo:load', setupImagePreview);
document.addEventListener('turbo:render', setupImagePreview);

// 関数を作成
function setupImagePreview() {
省略

```