### PR TITLE
urlはみ出さないよう修正

### DIFF
--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -38,16 +38,16 @@
     </div>
 
     <!-- 購入先URL -->
-    <div class="mb-3 flex flex-col">
-      <h1 class= "font-bold mb-1 text-1xl sm:text-2xl"><%= t('.url') %></h1>
+    <div class="mb-3">
+      <h1 class="font-bold mb-1 text-1xl sm:text-2xl"><%= t('.url') %></h1>
         <div class="font-bold container p-4 m-2 shadow-lg shadow-stone-800/90 bg-white rounded-md border border-stone-500">
           <% if @item.item_url.present? %>
-            <div class="underline underline-offset-2">
-              <%= link_to "#{@item.item_url}", "#{@item.item_url}" %>
+            <div class="truncate">
+              <%= link_to @item.item_url, @item.item_url %>
             </div>
           <% else %>
             <%= t('.no_url') %>
-          <% end%>
+          <% end %>
         </div>
     </div>
 


### PR DESCRIPTION
#210 

# 概要
購入先urlがはみ出さないよう修正。
`class="truncate"`を追記。

app/views/items/show.html.erb
```ruby
    <!-- 購入先URL -->
    <div class="mb-3">
      <h1 class="font-bold mb-1 text-1xl sm:text-2xl"><%= t('.url') %></h1>
        <div class="font-bold container p-4 m-2 shadow-lg shadow-stone-800/90 bg-white rounded-md border border-stone-500">
          <% if @item.item_url.present? %>
            <div class="truncate">
              <%= link_to @item.item_url, @item.item_url %>
            </div>
          <% else %>
            <%= t('.no_url') %>
          <% end %>
        </div>
    </div>
```
[![Image from Gyazo](https://i.gyazo.com/45edce30c3c97a79e4ab053afc2f0df5.png)](https://gyazo.com/45edce30c3c97a79e4ab053afc2f0df5)