### PR TITLE
診断詳細画面のレコメンド商品画像リサイズ対応

### DIFF
--- a/app/views/diagnoses/show.html.erb
+++ b/app/views/diagnoses/show.html.erb
@@ -45,7 +45,7 @@
             <div class="container max-w-sm p-1 shadow-lg shadow-stone-800/80 bg-stone-200 hover:bg-emerald-200 rounded-md transition duration-300">
               <div class="my-1">
                 <div class="mb-1 mx-12 flex justify-center">
-                  <%= image_tag item.item_image.url %>
+                  <%= image_tag item.item_image.show.url %>
                 </div>
                 <div class="mb-1">
                   <%= link_to item.title, item_path(item), class: "underline underline-offset-2 mb-1 text-1xl" %></h1>


### PR DESCRIPTION
#215 

# 概要
診断詳細画面のレコメンド商品画像リサイズ対応。
アップローダーのshow.urlを当てる。

- app/views/diagnoses/show.html.erb
```ruby
      <!-- 登録された商品提案 -->
      <h1 class= "font-bold mb-2 text-1xl sm:text-2xl text-stone-600"><%= t('.recommend_user_items') %></h1>
      <% if @recommend_items.present? %>
        <div class="grid grid-cols-1 mb-3 p-5 md:grid-cols-3 gap-4 bg-white rounded-md">
          <% @recommend_items.each do |item| %>
            <div class="container max-w-sm p-1 shadow-lg shadow-stone-800/80 bg-stone-200 hover:bg-emerald-200 rounded-md transition duration-300">
              <div class="my-1">
                <div class="mb-1 mx-12 flex justify-center">
                  <%= image_tag item.item_image.show.url %>
                </div>
                <div class="mb-1">
                  <%= link_to item.title, item_path(item), class: "underline underline-offset-2 mb-1 text-1xl" %></h1>
                </div>
                <div class="mb-1">
                  <%= link_to item.body, class: "underline underline-offset-2 text-2xl mb-1" %></h1>
                </div>
              </div>
              
 ```