### PR TITLE
item購入先をボタン式に修正・他レイアウト微修正

### DIFF
--- a/app/views/diagnoses/favorites.html.erb
+++ b/app/views/diagnoses/favorites.html.erb
@@ -1,5 +1,5 @@
 <% content_for(:title, t('.title')) %>
-<div class="container mx-auto text-center">
+<div class="max-w-screen-lg mx-auto text-center justify-center">
   <div class="mb-2">
     <div class="mb-1 font-bold text-2xl sm:text-3xl md:text-4xl">
       <h1><%= t('.title') %></h1>
@@ -22,7 +22,7 @@
 
   <!-- お気に入り診断一覧 -->
   <div class="mb-2 ">
-    <div class="mb-3 flex flex-wrap flex-col sm:flex-row justify-center">
+    <div class="mb-5 flex flex-wrap flex-col sm:flex-row justify-center">
       <% if @favorite_diagnoses.present? %>
         <div class="mx-auto grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
           <%= render partial: "diagnosis", collection: @favorite_diagnoses %>
@@ -31,6 +31,8 @@
         <div><%= t('.not_result') %></div>
       <% end %>
     </div>
+    <div>
     <%= paginate @favorite_diagnoses, theme: 'diagnoses' %>
+    </div>
   </div>
 </div>

--- a/app/views/diagnoses/index.html.erb
+++ b/app/views/diagnoses/index.html.erb
@@ -1,5 +1,5 @@
 <% content_for(:title, t('.title')) %>
-<div class="container mx-auto text-center">
+<div class="max-w-screen-lg mx-auto text-center justify-center">
   <div class="mb-2">
     <div class="mb-1 font-bold text-2xl sm:text-3xl md:text-4xl">
       <h1><%= t('.title') %></h1>
@@ -22,7 +22,7 @@
 
   <!-- 診断一覧 -->
   <div class="mb-2 ">
-    <div class="mb-3 flex flex-wrap flex-col sm:flex-row justify-center">
+    <div class="mb-5 flex flex-wrap flex-col sm:flex-row justify-center">
       <% if @diagnoses.present? %>
         <div class="mx-auto grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4 justify-center">
           <%= render @diagnoses %>
@@ -31,6 +31,8 @@
         <div><%= t('.not_result') %></div>
       <% end %>
     </div>
+    </div>
     <%= paginate @diagnoses, theme: 'diagnoses' %>
+    </div>
   </div>
 </div>

--- a/app/views/diagnoses/new.html.erb
+++ b/app/views/diagnoses/new.html.erb
@@ -1,5 +1,5 @@
 <% content_for(:title, t('.title')) %>
-<div class="container mx-auto text-center">
+<div class="max-w-screen-md mx-auto text-center justify-center">
   <div>
     <div class="mb-1 font-bold text-2xl sm:text-3xl md:text-4xl">
       <h1><%= t('.title') %></h1>

--- a/app/views/diagnoses/show.html.erb
+++ b/app/views/diagnoses/show.html.erb
@@ -1,5 +1,5 @@
 <% content_for(:title, t('.title')) %>
-<div class="container mx-auto text-center justify-center">
+<div class="max-w-screen-md mx-auto text-center justify-center">
   <div class="mb-1 font-bold text-2xl sm:text-3xl md:text-4xl">
     <h1><%= t('.title') %></h1>
   </div>

--- a/app/views/items/bookmarks.html.erb
+++ b/app/views/items/bookmarks.html.erb
@@ -15,7 +15,7 @@
 
     <!-- ブックマーク一覧 -->
     <div class="mb-2">
-        <div class="mb-3 flex flex-wrap flex-col sm:flex-row justify-center">
+        <div class="mb-5 flex flex-wrap flex-col sm:flex-row justify-center">
             <% if @bookmark_items.present? %>
                 <div class="mx-auto grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
                     <%= render partial: "item", collection: @bookmark_items %>
@@ -24,7 +24,9 @@
                 <div><%= t('.not_result') %></div>
             <% end %>
         </div>
+        <div>
         <%= paginate @bookmark_items, theme: 'diagnoses' %>
+        </div>
     </div>
 </div>
 

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for(:title, t('.title')) %>
-<div class="container mx-auto  text-center">
+<div class="max-w-screen-md mx-auto text-center justify-center">
     <div>
     <h1 class="font-bold text-2xl sm:text-3xl md:text-4xl"><%= t('.title') %></h1>
         <div class="p-2 m-2 bg-slate-200 rounded-md border-2 border-black">

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -1,5 +1,5 @@
 <% content_for(:title, t('.title')) %>
-<div class="container mx-auto text-center">
+<div class="max-w-screen-lg mx-auto text-center justify-center">
   <div class="mb-2">
     <div class="mb-1 font-bold text-2xl sm:text-3xl md:text-4xl">
       <h1><%= t('.title') %></h1>
@@ -13,17 +13,19 @@
 
   <hr class="border border-stone-300 my-4">
 
-  <!-- 診断一覧 -->
+  <!-- 登録アイテム一覧 -->
   <div class="mb-2">
-    <div class="mb-3 flex flex-wrap flex-col sm:flex-row justify-center">
+    <div class="mb-5 flex flex-wrap flex-col sm:flex-row justify-center">
       <% if @items.present? %>
-        <div class="mx-auto grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-5 gap-4">
+        <div class="mx-auto grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
           <%= render @items %>
         </div>
       <% else %>
         <div><%= t('.not_result') %></div>
       <% end %>
     </div>
+    <div>
     <%= paginate @items, theme: 'diagnoses' %>
+    </div>
   </div>
 </div>

--- a/app/views/items/new.html.erb
+++ b/app/views/items/new.html.erb
@@ -1,5 +1,5 @@
 <% content_for(:title, t('.title')) %>
-<div class="container mx-auto  text-center">
+<div class="max-w-screen-md mx-auto text-center justify-center">
   <div>
   <h1 class="font-bold text-2xl sm:text-3xl md:text-4xl"><%= t('.title') %></h1>
     <div class="p-2 m-2 bg-slate-200 rounded-md border-2 border-black">

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -1,69 +1,56 @@
 <% content_for(:title, t('.title')) %>
-<div class="container mx-auto text-center justify-center">
+<div class="max-w-screen-md mx-auto text-center justify-center">
   <div>
     <h1 class="font-bold text-2xl sm:text-3xl md:text-4xl"><%= t('.title') %></h1>
   </div>
-
   <div class="p-4 m-2 bg-slate-100 rounded-md border-2 border-black">
     <!-- アイテム画像 -->
     <div class="mb-3 flex justify-center ">
       <%= image_tag @item.item_image.show.url , class: "rounded-md border-2 border-black" %>
     </div>
-
     <!-- アイテム題名 -->
     <div class="mb-3 flex flex-col">
-      <div class= "font-bold mb-1 text-1xl sm:text-2xl">
-        <%= t('.item_title') %>
+      <h1 class= "mb-1 font-bold text-1xl sm:text-2xl"><%= t('.item_title') %></h1>
+      <div class= "mb-1 font-bold">
         <%= @item.title %>
       </div>
     </div>
-
-    <hr class="border border-stone-300 my-4">
-
+    <hr class="border border-stone-300 my-3">
+    <!-- 色分類 -->
+    <h1 class= "mb-2 font-bold text-1xl sm:text-2xl"><%= t('.color') %></h1>
+    <div class="flex justify-center">
+      <% @item.colors.each do |color| %>
+        <div class="px-1 py-1 mx-2 mb-2 border border-black rounded-md <%= button_color(color.name) %>" >
+            <%= color.name %>
+        </div>
+      <% end %>
+    </div>
+    <hr class="border border-stone-300 my-3">
     <!-- アイテム説明 -->
-    <div class="mb-3 flex flex-col">
-      <h1 class= "font-bold text-1xl sm:text-2xl"><%= t('.body') %></h1>
-        <div class="font-bold container p-4 m-2">
+    <div class="mb-2 flex flex-col">
+      <h1 class= "mb-2 font-bold text-1xl sm:text-2xl"><%= t('.body') %></h1>
+        <div class="font-bold container mb-1">
           <%= @item.body %>
         </div>
     </div>
-
-    <hr class="border border-stone-300 my-4">
-
-    <!-- 色 -->
-    <div class="mb-3 font-bold">
-      <h1 class= "mb-3 font-bold text-1xl sm:text-2xl"><%= t('.color') %></h1>
-      <div class="flex justify-center">
-        <% @item.colors.each do |color| %>
-          <div class="px-1 py-1 mx-2 mb-2 border border-black rounded-md <%= button_color(color.name) %>" >
-              <%= color.name %>
-          </div>
-        <% end %>
-      </div>
-    </div>
-
-    <hr class="border border-stone-300 my-4">
-
     <!-- 購入先URL -->
     <div class="mb-3">
-      <h1 class="font-bold mb-1 text-1xl sm:text-2xl"><%= t('.url') %></h1>
-        <div class="font-bold container p-4 m-2 shadow-lg shadow-stone-800/90 bg-white rounded-md border border-stone-500">
-          <% if @item.item_url.present? %>
-            <div class="truncate">
-              <%= link_to @item.item_url, @item.item_url %>
-            </div>
-          <% else %>
-            <%= t('.no_url') %>
-          <% end %>
+      <% if @item.item_url.present? %>
+        <div class="mb-2 inline-block bg-stone-100 hover:bg-emerald-300 font-bold mx-1 py-2 px-4 rounded transition duration-150 ease-in-out border border-black">
+          <%= link_to t('.item_url'), @item.item_url %>
         </div>
+      <% else %>
+        <%= t('.no_url') %>
+      <% end %>
     </div>
-
+    <hr class="border border-stone-300 my-3">
+    <!-- 一覧ページリンク -->
     <div class="flex items-center justify-center">
       <div class="mb-3">
         <%= link_to t('.item_index'), items_path, class: "inline-block bg-emerald-100 hover:bg-emerald-300 font-bold mx-1 py-2 px-4 rounded transition duration-150 ease-in-out border border-black"%>
       </div>
     </div>
-
+    <!-- 編集・削除ボタン -->
     <% if current_user&.own?(@item) %>
       <div class="mb-3 inline-block bg-emerald-100 hover:bg-emerald-300 font-bold mx-1 py-2 px-4 rounded transition duration-150 ease-in-out border border-black">
         <%= link_to t('.edit'), edit_item_path(@item) %>

--- a/app/views/password_resets/edit.html.erb
+++ b/app/views/password_resets/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for(:title, t('.title')) %>
-<div class="container mx-auto  text-center">
+<div class="max-w-screen-md mx-auto text-center justify-center">
   <h1 class="font-bold text-4xl my-3"><%= t('.title') %></h1>
   
   <div class="p-4 m-2 max-w-sm mx-auto bg-stone-300 rounded-md border-2 border-black">

--- a/app/views/password_resets/new.html.erb
+++ b/app/views/password_resets/new.html.erb
@@ -1,5 +1,5 @@
 <% content_for(:title, t('.title')) %>
-<div class="container mx-auto  text-center">
+<div class="max-w-screen-md mx-auto text-center justify-center">
   <h1 class="font-bold text-4xl my-3"><%= t('.title') %></h1>
   <div class="p-4 m-2 max-w-sm mx-auto bg-stone-300 rounded-md border-2 border-black">
     <%= form_with url: password_resets_path do |f| %>

--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for(:title, t('.title')) %>
-<div class="container mx-auto text-center pb-10">
+<div class="max-w-screen-lg mx-auto text-center justify-center">
   <h1 class="font-bold text-4xl my-1"><%= t('.title') %></h1>
   <div class="mb-3 max-w-sm mx-auto bg-stone-300 rounded-md border-2 border-black">
     <%= form_with model: @user, url: profile_path do |f| %>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -1,5 +1,5 @@
 <% content_for(:title, t('.title')) %>
-<div class="container mx-auto text-center pb-10">
+<div class="max-w-screen-lg mx-auto text-center justify-center">
   <h1 class="mb-1 font-bold text-2xl sm:text-3xl md:text-4xl"><%= t('.title') %></h1>
   <div class="p-2 mb-5 max-w-sm mx-auto bg-stone-300 rounded-md border-2 border-black">
     <%= t('.name') %>

--- a/app/views/top_pages/top.html.erb
+++ b/app/views/top_pages/top.html.erb
@@ -1,13 +1,12 @@
-<div class="container mx-auto  text-center", data-title="<%= yield(:title) %>" >
+<div class="max-w-screen-lg mx-auto text-center justify-center", data-title="<%= yield(:title) %>" >
   <div class="relative mt-10 p-10">
     <div class="absolute inset-0 bg-no-repeat "></div>
-    <!-- 背景画像だけ半透明に設定 -->
     <div class="relative">
       <div class="flex justify-around flex-col md:flex-row items-center">
         <div class="px-5 font-bold">
           <p class="text-4xl sm:text-6xl mb-10">デスク色彩診断</p>
-          <p class="text-1xl mb-1">あなたは普段のデスクワークでの作業に集中できていますか？</p>
-          <p class="text-1xl mb-1">最後にデスク環境を見直したのは？</p>
+          <p class="text-1xl mb-1">普段のデスクワークでの作業に集中できていますか？</p>
+          <p class="text-1xl mb-1">最後にデスク環境を見直したのはいつですか？</p>
           <p class="text-1xl mb-4">このサービスは色彩の観点からあなたのデスク環境改善をサポートします。</p>
           <p class="mb-4 text-2xl sm:text-1xl">早速診断しましょう。</p>
           <%= link_to '診断する', new_diagnosis_path, class: "inline-block bg-amber-100 hover:bg-amber-500 text-black font-bold text-2xl mb-3 py-2 px-4 rounded-md transition duration-150 ease-in-out border border-black" %>
@@ -22,22 +21,19 @@
       </div>
     </div>
   </div>
-
-  <div class="bg-stone-100 p-2">
+  <!-- サービス説明欄 -->
+  <div class="bg-stone-100 p-3 border-2 border-stone-500 rounded-md">
     <p class="font-bold text-2xl py-2">このサービスについて</p>
-    <p class="border-2 border-stone-500 mx-4 mb-2">
-
+    <p class="border-2 border-stone-500 mx-4">
     <div class="flex justify-center items-center">
       <div class="font-bold mb-4">
-        <%= image_tag 'camera.png', class: "mb-4 px-5"%> 
+        <%= image_tag 'camera.png', class: ""%> 
           <p class="mb-3 text-2xl">診断 STEP 1</p>
           <p class="mb-1">あなたのデスク環境の写真を撮影して下さい。</p>
           <p class="mb-1 text-red-500">※ 部外秘情報が映らないよう注意して下さい。</p>
       </div>
     </div>
-
     <hr class="border-2 border-stone-500 mx-4 mb-8">
-
     <div class="flex justify-center items-center">
       <div class="font-bold mb-4">
         <%= image_tag 'diagnosis_top.png', class: "w-128 h-64 mb-4 px-5"%>
@@ -47,9 +43,7 @@
           <p class="mb-1 text-red-500">※ 診断はログイン後、1日2回までです。</p>
       </div>
     </div>
-
     <hr class="border-2 border-stone-500 mx-4 mb-8">
-    
     <div class="flex justify-center items-center">
       <div class="font-bold mb-4">
         <div class="mb-2">
@@ -61,13 +55,11 @@
         <p class="mb-1">自分のデスク環境に合った物が見つかるかもしれません。</p>
       </div>
     </div>
-
     <hr class="border-2 border-stone-500 m-4">
-    
     <div class="flex justify-center items-center">
       <div class="flex flex-col md:flex-row items-center">
         <div class="font-bold m-4">
-          <%= image_tag 'item_index.png', class: "w-128 h-64 mb-4 px-5" %>
+          <%= image_tag 'item_index.png', class: "w-128 h-64 mb-4" %>
           <p class="mb-2 text-2xl">デスク周辺アイテムを登録</p>
           <p class="mb-1">使用中のデスク周辺アイテムを登録できます。</p>
           <p class="mb-1">登録するとデスク診断結果に対するレコメンドアイテムとして表示されます。</p>
@@ -75,7 +67,7 @@
         </div>
       </div>
     </div>
-
+    <hr class="border-2 border-stone-500 mx-4 mb-8">
     <div class="font-bold">
       <p class="m-4 text-2xl">早速診断しましょう。</p>
       <%= link_to '診断する', new_diagnosis_path, class: "inline-block bg-amber-100 hover:bg-amber-500 text-black font-bold text-2xl mb-3 py-2 px-4 rounded-md transition duration-150 ease-in-out border border-black" %>

--- a/app/views/user_sessions/new.html.erb
+++ b/app/views/user_sessions/new.html.erb
@@ -1,5 +1,5 @@
 <% content_for(:title, t('.title')) %>
-<div class="container mx-auto text-center">
+<div class="max-w-screen-md mx-auto text-center justify-center">
   <h1 class="font-bold text-4xl"><%= t('.title') %></h1>
 
   <div class="p-4 m-2 max-w-sm mx-auto bg-stone-300 rounded-md border-2 border-black">

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -1,5 +1,5 @@
 <% content_for(:title, t('.title')) %>
-<div class="container mx-auto  text-center">
+<div class="max-w-screen-md mx-auto text-center justify-center">
   <h1 class="font-bold text-4xl"><%= t('.title') %></h1></h1>
   
   <div class="p-4 m-2 max-w-sm mx-auto bg-stone-300 rounded-md border-2 border-black">

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -124,10 +124,12 @@ ja:
       url_sample: 例 :https://www.example.co.jp/・・・
     show:
       title: 商品詳細
-      item_title: 題名：
-      body: 商品説明
-      color: 色分類
-      url: 商品購入先URL
+      item_title: 【題名(商品名)】
+      body: 【商品説明】
+      color: 【以下の配色を増やしたい場合にオススメ】
+      url: 商品購入先
+      item_url: 〜 購入先はこちら 〜
+      no_url: ※ こちらは購入先が未設定です
       sns_share: シェア
       diagnosis_index: デスク診断一覧
       item_index: 登録商品一覧


### PR DESCRIPTION
#227 

# 概要
アイテム詳細画面の購入先urlをボタン形式に修正。
[![Image from Gyazo](https://i.gyazo.com/f14b9e1d58d83d3bf7f2c948a5ff6101.png)](https://gyazo.com/f14b9e1d58d83d3bf7f2c948a5ff6101)