### PR TITLE
独自ドメインを本番環境ホストに許可

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -104,5 +104,5 @@ Rails.application.configure do
   config.active_record.dump_schema_after_migration = false
 
   # 独自ドメインをホスト許可
-  config.hosts << 'www.desk-shikisai-shindan.com'
+  config.hosts << 'desk-shikisai-shindan.com'
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -104,5 +104,5 @@ Rails.application.configure do
   config.active_record.dump_schema_after_migration = false
 
   # 独自ドメインをホスト許可
-  config.hosts << 'desk-shikisai-shindan.com'
+  config.hosts << 'www.desk-shikisai-shindan.com'
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -102,4 +102,7 @@ Rails.application.configure do
 
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
+
+  # 独自ドメインをホスト許可
+  config.hosts << 'www.desk-shikisai-shindan.com'
 end


### PR DESCRIPTION
#191 

# 概要
お名前.comで取得した独自ドメインをアプリケーション側で許可

config/environments/production.rb
```ruby
Rails.application.configure do

  # 独自ドメインをホスト許可
  config.hosts << 'www.desk-shikisai-shindan.com'
end
```