### PR TITLE
画像バリデーション実装

### DIFF
--- a/app/models/diagnosis.rb
+++ b/app/models/diagnosis.rb
@@ -4,7 +4,7 @@ class Diagnosis < ApplicationRecord
     validate :desk_image_must_not_be_default
     validates :place_id, presence: true
     validates :desk_work, presence: true, length: { maximum: 255 }
-    # validate :user_diagnosis_limit, on: :create
+    validate :user_diagnosis_limit, on: :create
     validate :validate_image_analysis, on: :create
 
     belongs_to :user
@@ -41,7 +41,7 @@ class Diagnosis < ApplicationRecord
     # 診断機能を1日2回までに制限
     def user_diagnosis_limit
         today_diagnoses = user.diagnoses.where('created_at >= ?', Time.zone.now.beginning_of_day)
-        if today_diagnoses.count >= 2
+        if today_diagnoses.count >= 1
             errors.add(:base, '1日の診断回数の上限に達しました。')
         end
     end

--- a/app/models/diagnosis.rb
+++ b/app/models/diagnosis.rb
@@ -4,16 +4,25 @@ class Diagnosis < ApplicationRecord
     validate :desk_image_must_not_be_default
     validates :place_id, presence: true
     validates :desk_work, presence: true, length: { maximum: 255 }
-    validate :user_diagnosis_limit, on: :create
+    # validate :user_diagnosis_limit, on: :create
+    validate :validate_image_analysis, on: :create
 
     belongs_to :user
     belongs_to :place
 
     has_many :favorites, dependent: :destroy
 
+    # 診断する写真を添付したか？
     def desk_image_must_not_be_default
         if desk_image.default_image?
             errors.add(:desk_image, "を選択してください。")
+        end
+    end
+
+    # Google Cloud Vision APIの解析結果検証
+    def validate_image_analysis
+        if color_info.blank?
+            errors.add(:base, :image_analysis_failed, message: "写真から十分なデスク領域が見つかりませんでした。")
         end
     end
 

--- a/app/services/google_cloud_vision_api.rb
+++ b/app/services/google_cloud_vision_api.rb
@@ -11,10 +11,10 @@ class GoogleCloudVisionApi
                 image: {
                 content: image_data
                 },
-                features: [{
-                type: "IMAGE_PROPERTIES",
-                maxResults: 10
-                }]
+                features: [
+                {type: "IMAGE_PROPERTIES", maxResults: 10 },
+                {type: "LABEL_DETECTION", maxResults: 10 }
+                ]
             }]
         }.to_json
     
@@ -24,21 +24,35 @@ class GoogleCloudVisionApi
         http.use_ssl = true
         request = Net::HTTP::Post.new(uri.request_uri, {'Content-Type' => 'application/json'})
         request.body = body
-    
+
         # リクエストを送信→レスポンス受け取り。
         response = http.request(request)
+
         # レスポンスのHTTPステータスコードが200の場合、レスポンスボディから色情報を抽出。
         if response.code == '200'
-            color_full_data = JSON.parse(response.body)['responses'][0]['imagePropertiesAnnotation']['dominantColors']['colors']
-            # 色の画面支配率（pixelFraction）で降順にソート
-            sorted_by_pixel_fraction = color_full_data.sort_by { |color_info| -color_info['pixelFraction'] }
-            # 文字数削減のため、必要な数値部分のみ抽出。
-            sorted_by_pixel_fraction.map do |color_info|
-                color = color_info['color'].values.join(", ").split(', ').map(&:to_i).join(", ") # RGB値の値を抽出。
-                score = (color_info['score']*100).round(3)                                       # 各色の支配率スコアを抽出。
-                pixelFraction = (color_info['pixelFraction']*100).round(3)                       # 各色の画像内のどれくらいの割合のピクセルを占めているかを抽出。
-                "#{color}: #{score} :#{pixelFraction}"
+            label_data = JSON.parse(response.body)['responses'][0]['labelAnnotations']
+            # ラベル情報から条件を満たすものを検索
+            desk_or_table_with_high_score = label_data.any? do |label_info|
+                # ラベルの記述が'desk'または'table'で（大文字も含む）、かつスコアが90以上であるかどうかを確認
+                %w[desk table].include?(label_info['description'].downcase) &&
+                (label_info['score'] * 100).round(3) >= 90
             end
+            return false unless desk_or_table_with_high_score
+            # もしラベルが確認できた場合、色情報の抽出。
+            if desk_or_table_with_high_score
+                color_full_data = JSON.parse(response.body)['responses'][0]['imagePropertiesAnnotation']['dominantColors']['colors']
+                # 色の画面支配率（pixelFraction）で降順にソート
+                sorted_by_pixel_fraction = color_full_data.sort_by { |color_info| -color_info['pixelFraction'] }
+                # 文字数削減のため、必要な数値部分のみ抽出。
+                sorted_by_pixel_fraction.map do |color_info|
+                    color = color_info['color'].values.join(", ").split(', ').map(&:to_i).join(", ") # RGB値の値を抽出。
+                    score = (color_info['score']*100).round(3)                                       # 各色の支配率スコアを抽出。
+                    pixelFraction = (color_info['pixelFraction']*100).round(3)                       # 各色の画像内のどれくらいの割合のピクセルを占めているかを抽出。
+                    "#{color}: #{score} :#{pixelFraction}"
+                end
+            end
+        else
+            false
         end
     end
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -104,5 +104,6 @@ Rails.application.configure do
   config.active_record.dump_schema_after_migration = false
 
   # 独自ドメインをホスト許可
+  config.hosts << 'from-your-desk.onrender.com'
   config.hosts << 'www.desk-shikisai-shindan.com'
 end

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -8,6 +8,7 @@ ja:
   flash_message:
     diagnosed: "診断完了"
     not_diagnosed: "診断出来ませんでした"
+    not_label: "写真から十分なデスク領域を検出できませんでした"
     created: "%{item}を作成しました"
     not_created: "%{item}を作成出来ませんでした"
     update: "%{item}を更新しました"


### PR DESCRIPTION
#230 

# 概要
デスク診断時にデスクを含まない写真を受け付けないよう実装。

- [x] app/models/diagnosis.rbにカスタムバリデーション追加。

```ruby
class Diagnosis < ApplicationRecord
    validate :validate_image_analysis, on: :create

    # Google Cloud Vision APIの解析結果検証
    def validate_image_analysis
        if color_info.blank?
            errors.add(:base, :image_analysis_failed, message: "写真から十分なデスク領域が見つかりませんでした。")
        end
    end
```

- [x] app/services/google_cloud_vision_api.rbでラベルを検出できたら色情報を抽出するよう修正

```ruby
        # レスポンスのHTTPステータスコードが200の場合、レスポンスボディから色情報を抽出。
        if response.code == '200'
            label_data = JSON.parse(response.body)['responses'][0]['labelAnnotations']
            # ラベル情報から条件を満たすものを検索
            desk_or_table_with_high_score = label_data.any? do |label_info|
                # ラベルの記述が'desk'または'table'で（大文字も含む）、かつスコアが90以上であるかどうかを確認
                %w[desk table].include?(label_info['description'].downcase) &&
                (label_info['score'] * 100).round(3) >= 90
            end
            return false unless desk_or_table_with_high_score
            # もしラベルが確認できた場合、色情報の抽出。
            if desk_or_table_with_high_score
                color_full_data = JSON.parse(response.body)['responses'][0]['imagePropertiesAnnotation']['dominantColors']['colors']
                # 色の画面支配率（pixelFraction）で降順にソート
                sorted_by_pixel_fraction = color_full_data.sort_by { |color_info| -color_info['pixelFraction'] }
                # 文字数削減のため、必要な数値部分のみ抽出。
                sorted_by_pixel_fraction.map do |color_info|
                    color = color_info['color'].values.join(", ").split(', ').map(&:to_i).join(", ") # RGB値の値を抽出。
                    score = (color_info['score']*100).round(3)                                       # 各色の支配率スコアを抽出。
                    pixelFraction = (color_info['pixelFraction']*100).round(3)                       # 各色の画像内のどれくらいの割合のピクセルを占めているかを抽出。
                    "#{color}: #{score} :#{pixelFraction}"
                end
            end
        else
            false
        end
```

- [x] app/controllers/diagnoses_controller.rbでサービスクラスの結果がtrueの場合は処理を進めるよう修正

```ruby
    if uploaded_image_path.present?
      analyze_result = GoogleCloudVisionApi.analyze_image(uploaded_image_path)
      @diagnosis.color_info = analyze_result if analyze_result
    end
```