### PR TITLE
googleのoauthに独自ドメイン設定反映

### DIFF
--- a/config/settings/production.yml
+++ b/config/settings/production.yml
@@ -1,5 +1,5 @@
 sorcery:
-  google_callback_url: "https://desk-shikisai-shindan.com.onrender.com/oauth/callback?provider=google"
+  google_callback_url: "https://desk-shikisai-shindan.com/oauth/callback?provider=google"
 
 default_url_options:
   protcol: 'https'

--- a/config/settings/production.yml
+++ b/config/settings/production.yml
@@ -3,4 +3,4 @@ sorcery:
 
 default_url_options:
   protcol: 'https'
-  host: 'from-your-desk.onrender.com'
+  host: 'desk-shikisai-shindan.com'

--- a/config/settings/production.yml
+++ b/config/settings/production.yml
@@ -1,5 +1,5 @@
 sorcery:
-  google_callback_url: "https://from-your-desk.onrender.com/oauth/callback?provider=google"
+  google_callback_url: "https://desk-shikisai-shindan.com.onrender.com/oauth/callback?provider=google"
 
 default_url_options:
   protcol: 'https'


### PR DESCRIPTION
#234 

# 概要
 googleのoauth設定に独自ドメインを適用。
- config/settings/production.yml
```ruby
sorcery:
  google_callback_url: "https://desk-shikisai-shindan.com.onrender.com/oauth/callback?provider=google"

default_url_options:
  protcol: 'https'
  host: 'desk-shikisai-shindan.com'
```