### PR TITLE
Refactor diagnosis action

### DIFF
--- a/app/controllers/diagnoses_controller.rb
+++ b/app/controllers/diagnoses_controller.rb
@@ -12,7 +12,7 @@ class DiagnosesController < ApplicationController
 
   def show
     @diagnosis = Diagnosis.find_by(id: params[:id])
-    # 診断結果にあった登録商品をランダムに３つ取得
+    # 診断結果に応じたオススメ登録商品をDBからランダムに３つ表示
     @recommend_items = Item.joins(:colors).where("colors.name LIKE ?", "%#{@diagnosis.color_name.gsub(/（.*?）/, '')}%").order(Arel.sql("RANDOM()")).limit(3)
   end
 
@@ -23,27 +23,10 @@ class DiagnosesController < ApplicationController
 
   def diagnosis
     @diagnosis = current_user.diagnoses.build(diagnosis_params)
-    #.tempfileメソッド：アップロードされたファイルが一時的に保存されているTempfileオブジェクトにアクセスするためのメソッド。
-    # .pathメソッドでそのTempfileオブジェクトのファイルシステム上のパスを取得。(後続の処理で画像ファイルを読み込んだり、外部のAPIに送信したりするために使用されるパス)
-    if params[:diagnosis][:desk_image].present?
-      uploaded_image_path = params[:diagnosis][:desk_image].tempfile.path
-    end
-
-    if uploaded_image_path.present?
-      analyze_result = GoogleCloudVisionApi.analyze_image(uploaded_image_path)
-      @diagnosis.color_info = analyze_result if analyze_result
-    end
-
-    if @diagnosis.color_info.present? && @diagnosis.place_id.present?
-      response = OpenAiApi.chat(@diagnosis.color_info, @diagnosis.desk_work, Place.find_by(id: @diagnosis.place_id).name)
-      @diagnosis.result_en = response.dig("choices", 0, "message", "content") 
-    end
-
-    if @diagnosis.result_en.present?
-      translated_response = DeeplApi.translate(@diagnosis.result_en, 'JA') # 診断結果翻訳
-      @diagnosis.color_name = translated_response.slice(/【(.*?)】/, 1).gsub(/（.*?）/, '') # 診断結果から色名を抽出（「色名（カタカナ）」の場合は（）部分を除去）
-      @diagnosis.result_jp = translated_response # 診断結果全文
-    end
+    # private配下メソッド実行
+    process_image if params[:diagnosis][:desk_image].present?
+    analyze_color_info if @diagnosis.color_info.present?
+    translate_result if @diagnosis.result_en.present?
 
     if @diagnosis.save
       redirect_to diagnosis_path(@diagnosis), success: t('flash_message.diagnosed')
@@ -63,5 +46,25 @@ class DiagnosesController < ApplicationController
 
   def diagnosis_params
     params.require(:diagnosis).permit(:desk_image, :desk_work, :desk_image_cache, :place_id)
+  end
+
+  # 画像診断・色情報抽出
+  def process_image
+    uploaded_image_path = params[:diagnosis][:desk_image].tempfile.path      #.tempfileメソッド：アップロードされたファイルが一時的に保存されているTempfileオブジェクトにアクセスするためのメソッド。
+    analyze_result = GoogleCloudVisionApi.analyze_image(uploaded_image_path) # .pathメソッドでそのTempfileオブジェクトのファイルシステム上のパスを取得。(後続の処理で画像ファイルを読み込んだり、外部のAPIに送信したりするために使用されるパス)
+    @diagnosis.color_info = analyze_result if analyze_result
+  end
+
+  # 診断文章生成
+  def analyze_color_info
+    response = OpenAiApi.chat(@diagnosis.color_info, @diagnosis.desk_work)
+    @diagnosis.result_en = response.dig("choices", 0, "message", "content")
+  end
+
+  # 診断結果翻訳
+  def translate_result
+    translated_response = DeeplApi.translate(@diagnosis.result_en, 'JA')                 # 診断結果翻訳
+    @diagnosis.color_name = translated_response.slice(/【(.*?)】/, 1).gsub(/（.*?）/, '') # 診断結果から色名を抽出（「色名（カタカナ）」の場合は（）部分を除去）
+    @diagnosis.result_jp = translated_response
   end
 end

--- a/app/models/diagnosis.rb
+++ b/app/models/diagnosis.rb
@@ -41,7 +41,7 @@ class Diagnosis < ApplicationRecord
     # 診断機能を1日2回までに制限
     def user_diagnosis_limit
         today_diagnoses = user.diagnoses.where('created_at >= ?', Time.zone.now.beginning_of_day)
-        if today_diagnoses.count >= 1
+        if today_diagnoses.count >= 2
             errors.add(:base, '1日の診断回数の上限に達しました。')
         end
     end

--- a/app/services/open_ai_api.rb
+++ b/app/services/open_ai_api.rb
@@ -1,5 +1,5 @@
 class OpenAiApi
-    def self.chat(color_info, desk_work, desk_place)
+    def self.chat(color_info, desk_work)
         @client = OpenAI::Client.new(access_token: ENV['OPENAI_API_KEY'])
         @client.chat(
             parameters: {


### PR DESCRIPTION
 #242 

# 概要

- [x] diagnosisアクションが冗長だったので、privateメソッドに分けて冗長化を解決。

- app/controllers/diagnoses_controller.rb
```ruby
class DiagnosesController < ApplicationController
  skip_before_action :require_login, only: %i[index show]

 # 省略

  def diagnosis
    @diagnosis = current_user.diagnoses.build(diagnosis_params)
    # private配下メソッド実行
    process_image if params[:diagnosis][:desk_image].present?
    analyze_color_info if @diagnosis.color_info.present?
    translate_result if @diagnosis.result_en.present?

    if @diagnosis.save
      redirect_to diagnosis_path(@diagnosis), success: t('flash_message.diagnosed')
    else
      flash.now[:danger] = t('flash_message.not_diagnosed')
      render :new, status: :unprocessable_entity
    end
  end

 # 省略

  private

  def diagnosis_params
    params.require(:diagnosis).permit(:desk_image, :desk_work, :desk_image_cache, :place_id)
  end

  # 画像診断・色情報抽出
  def process_image
    uploaded_image_path = params[:diagnosis][:desk_image].tempfile.path      #.tempfileメソッド：アップロードされたファイルが一時的に保存されているTempfileオブジェクトにアクセスするためのメソッド。
    analyze_result = GoogleCloudVisionApi.analyze_image(uploaded_image_path) # .pathメソッドでそのTempfileオブジェクトのファイルシステム上のパスを取得。(後続の処理で画像ファイルを読み込んだり、外部のAPIに送信したりするために使用されるパス)
    @diagnosis.color_info = analyze_result if analyze_result
  end

  # 診断文章生成
  def analyze_color_info
    response = OpenAiApi.chat(@diagnosis.color_info, @diagnosis.desk_work)
    @diagnosis.result_en = response.dig("choices", 0, "message", "content")
  end

  # 診断結果翻訳
  def translate_result
    translated_response = DeeplApi.translate(@diagnosis.result_en, 'JA')                 # 診断結果翻訳
    @diagnosis.color_name = translated_response.slice(/【(.*?)】/, 1).gsub(/（.*?）/, '') # 診断結果から色名を抽出（「色名（カタカナ）」の場合は（）部分を除去）
    @diagnosis.result_jp = translated_response
  end
end

```