### PR TITLE
Ref: 診断結果一覧のアバター画像部分のレイアウト微修正

### DIFF
--- a/app/views/diagnoses/_diagnosis.html.erb
+++ b/app/views/diagnoses/_diagnosis.html.erb
@@ -32,7 +32,7 @@
 
         <!-- アバター・ユーザー名・診断日時 -->
         <div class="flex justify-center items-center">
-            <div class="px-4">
+            <div class="px-2">
                 <% if diagnosis.user.google_avatar_image.blank? %>
                     <%= image_tag diagnosis.user.avatar_image_url, class: "h-10 w-10 object-cove rounded-full" %>
                 <% else %>


### PR DESCRIPTION
#253

# 概要
診断結果一覧のアバター画像が少し歪んでいるのを修正
- [x] `px-4`から`px-2`に修正
- app/views/diagnoses/_diagnosis.html.erb
```ruby
        <!-- アバター・ユーザー名・診断日時 -->
        <div class="flex justify-center items-center">
            <div class="px-2">
                <% if diagnosis.user.google_avatar_image.blank? %>
                    <%= image_tag diagnosis.user.avatar_image_url, class: "h-10 w-10 object-cove rounded-full" %>
                <% else %>
                    <%= image_tag diagnosis.user.google_avatar_image, class: "h-10 w-10 object-cove rounded-full" %>
                <% end %>
            </div> 
            <div class="pr-2 flex flex-col">
                <%= diagnosis.user.name %><br>
                <%= l diagnosis.created_at, format: :long %>
            </div>
```