### PR TITLE
Add: Dignosisモデルスペック実装

### DIFF
--- a/app/models/diagnosis.rb
+++ b/app/models/diagnosis.rb
@@ -20,7 +20,7 @@ class Diagnosis < ApplicationRecord
 
   # Google Cloud Vision APIの解析結果検証
   def validate_image_analysis
-    return unless color_info.blank?
+    return unless result_en.blank?
     errors.add(:base, :image_analysis_failed, message: '写真から十分なデスク領域が見つかりませんでした。')
   end
 

--- a/app/services/google_cloud_vision_api.rb
+++ b/app/services/google_cloud_vision_api.rb
@@ -39,7 +39,6 @@ class GoogleCloudVisionApi
       end
       return false unless desk_or_table_with_high_score
 
-      # もしラベルが確認できた場合、色情報の抽出。
       if desk_or_table_with_high_score
         color_full_data = JSON.parse(response.body)['responses'][0]['imagePropertiesAnnotation']['dominantColors']['colors']
         # 色の画面支配率（pixelFraction）で降順にソート

--- a/spec/factories/categories.rb
+++ b/spec/factories/categories.rb
@@ -1,0 +1,13 @@
+FactoryBot.define do
+    factory :category do
+        name { "作業区分" }
+    end
+end
+
+# trait :office do
+#     name { "オフィス" }
+# end
+
+# trait :home do
+#     name { "在宅" }
+# end

--- a/spec/factories/diagnoses.rb
+++ b/spec/factories/diagnoses.rb
@@ -1,6 +1,9 @@
 FactoryBot.define do
   factory :diagnosis do
     desk_work { "デスクワーク" }
+    color_name { "赤" }
+    result_en { "diagnosis_result" }
+    result_jp { "診断結果" }
     association :user
     association :place
 

--- a/spec/factories/places.rb
+++ b/spec/factories/places.rb
@@ -1,11 +1,31 @@
 FactoryBot.define do
     factory :place do
-        trait :office do
-            name { "オフィス" }
-        end
-
-        trait :home do
-            name { "在宅" }
-        end
+        name { "自室" }
+        association :category
     end
 end
+
+        # trait :living do
+        #     name { "リビング" }
+        # end
+
+        # trait :dining do
+        #     name { "ダイニング" }
+        # end
+
+        # trait :other do
+        #     name { "その他" }
+        # end
+
+        # trait :study do
+        #     name { "書斎" }
+        # end
+
+        # trait :free_address do
+        #     name { "フリーアドレス" }
+        # end
+
+        # trait :fixed_seat do
+        #     name { "固定席" }
+        # end
+    # end

--- a/spec/models/diagnosis_spec.rb
+++ b/spec/models/diagnosis_spec.rb
@@ -1,30 +1,39 @@
 require 'rails_helper'
 
 RSpec.describe Diagnosis, type: :model do
+    let(:user) { create(:user) }
+    let(:place) { create(:place) }
+    let(:diagnosis) { build(:diagnosis, user: user, place: place) }
+
     context '正常系' do
         it 'すべてのフィールドが正常の場合、有効であること' do
-            diagnosis = build(:diagnosis)
             expect(diagnosis).to be_valid
         end
     end
 
     context '異常系' do
         it 'デスクワーク内容が未入力の場合、無効であること' do
+            diagnosis.desk_work = nil
+            expect(diagnosis).to be_invalid
+            expect(diagnosis.errors[:desk_work]).to include('を入力してください')
         end
 
         it 'デスクワークの内容が256文字以上の場合、無効であること' do
+            diagnosis.desk_work = 'a' * 256
+            expect(diagnosis).to be_invalid
+            expect(diagnosis.errors[:desk_work]).to include('は255文字以内で入力してください')
         end
 
         it 'デスク環境場所が未選択の場合、無効であること' do
+            diagnosis.place_id = nil
+            expect(diagnosis).to be_invalid
+            expect(diagnosis.errors[:place_id]).to include('を入力してください')
         end
 
         it 'デスク写真が未設定の場合、無効であること' do
-        end
-
-        it 'デスクを含まない写真を設定した場合、無効であること' do
-        end
-
-        it '診断機能を同じ日に3回以上実施した場合、無効であること' do
+            diagnosis.desk_image = nil
+            expect(diagnosis).to be_invalid
+            expect(diagnosis.errors[:desk_image]).to include('を選択してください。')
         end
     end
 end

--- a/spec/models/favorite_spec.rb
+++ b/spec/models/favorite_spec.rb
@@ -3,17 +3,17 @@ require 'rails_helper'
 RSpec.describe Favorite, type: :model do
     context '正常系' do
         it '全てのフィールドが正常な場合、有効であること' do
-            # favorite = build(:favorite)
-            # expect(favorite).to be_valid
+            favorite = build(:favorite)
+            expect(favorite).to be_valid
         end
     end
 
     context '異常系' do
         it 'ユーザーと掲示板の組み合わせがユニークでない場合,無効であること' do
-            # favotite = create(:favorite)
-            # new_favorite = build(:favorite, user: favorite.user, board: favorite.board)
-            # new_favorite.valid?
-            # expect(new_favorite.errors[:user_id]).to include('はすでに存在します'), 'favoriteとuserのユニークバリデーションが設定されていません'
+            favorite = create(:favorite)
+            new_favorite = build(:favorite, user: favorite.user, diagnosis: favorite.diagnosis)
+            new_favorite.valid?
+            expect(new_favorite.errors[:user_id]).to include('はすでに存在します'), 'favoriteとuserのユニークバリデーションが設定されていません'
         end
     end
 end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -34,12 +34,6 @@ RSpec.describe Item, type: :model do
             expect(item.errors[:body]).to include('は255文字以内で入力してください')
         end
 
-        # it 'カテゴリーが未選択の場合、無効であること' do
-        #     item = build(:item, item_category_id: nil)
-        #     expect(item).to be_invalid
-        #     expect(item.errors[:item_category_id]).to include('を入力してください')
-        # end
-
         it '色分類が未選択の場合、無効であること' do
             item.colors = []
             expect(item).to be_invalid

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -65,5 +65,5 @@ RSpec.configure do |config|
   # config.filter_gems_from_backtrace("gem name")
 
   # Sorceryのテストヘルパーを利用
-  # config.include Sorcery::TestHelpers::Rails::Request, type: :request
+  config.include Sorcery::TestHelpers::Rails::Request, type: :request
 end


### PR DESCRIPTION
#261 

# 概要

- [x] Diagnosisモデルスペック実装

spec/factories/diagnoses.rb
```ruby
FactoryBot.define do
  factory :diagnosis do
    desk_work { "デスクワーク" }
    color_name { "赤" }
    result_en { "diagnosis_result" }
    result_jp { "診断結果" }
    association :user
    association :place

    after(:build) do |diagnosis|
      diagnosis.desk_image = Rack::Test::UploadedFile.new('spec/fixtures/desk_image.jpg', 'image/jpeg')
    end
  end
end

```

spec/models/diagnosis_spec.rb
```ruby
require 'rails_helper'

RSpec.describe Diagnosis, type: :model do
    let(:user) { create(:user) }
    let(:place) { create(:place) }
    let(:diagnosis) { build(:diagnosis, user: user, place: place) }

    context '正常系' do
        it 'すべてのフィールドが正常の場合、有効であること' do
            expect(diagnosis).to be_valid
        end
    end

    context '異常系' do
        it 'デスクワーク内容が未入力の場合、無効であること' do
            diagnosis.desk_work = nil
            expect(diagnosis).to be_invalid
            expect(diagnosis.errors[:desk_work]).to include('を入力してください')
        end

        it 'デスクワークの内容が256文字以上の場合、無効であること' do
            diagnosis.desk_work = 'a' * 256
            expect(diagnosis).to be_invalid
            expect(diagnosis.errors[:desk_work]).to include('は255文字以内で入力してください')
        end

        it 'デスク環境場所が未選択の場合、無効であること' do
            diagnosis.place_id = nil
            expect(diagnosis).to be_invalid
            expect(diagnosis.errors[:place_id]).to include('を入力してください')
        end

        it 'デスク写真が未設定の場合、無効であること' do
            diagnosis.desk_image = nil
            expect(diagnosis).to be_invalid
            expect(diagnosis.errors[:desk_image]).to include('を選択してください。')
        end
    end
end

```