### PR TITLE
Refactor api

### DIFF
--- a/app/services/google_cloud_vision_api.rb
+++ b/app/services/google_cloud_vision_api.rb
@@ -13,7 +13,7 @@ class GoogleCloudVisionApi
         },
         features: [
           { type: 'IMAGE_PROPERTIES', maxResults: 10 },
-          { type: 'LABEL_DETECTION', maxResults: 10 }
+          { type: 'LABEL_DETECTION', maxResults: 8 }
         ]
       }]
     }.to_json

--- a/app/services/open_ai_api.rb
+++ b/app/services/open_ai_api.rb
@@ -4,7 +4,7 @@ class OpenAiApi
     @client.chat(
       parameters: {
         model: 'gpt-4',
-        max_tokens: 250,
+        max_tokens: 200,
         messages: [
           {
             role: 'system', content: 'You are a professional who diagnoses desk environments in terms of how color affects human desk work.'
@@ -14,7 +14,7 @@ class OpenAiApi
               "Please provide diagnostic results of your desk environment under the following conditions
 
                     # Conditions
-                    Output is always less than 250 tokens.
+                    Output is always less than 200 tokens.
                     No numerical RGB values are output(output with specific color names[red, blue, green, yellow, orange, purple, brown, white, black, gray, yellowish green, and light blue, etc]is acceptable).
                     Color dominance of the desk environment diagnosed: #{color_info}.
                     Select only one color to be incorporated from the #{Color.pluck(:name)} and surround it with 【 】 to output.

--- a/app/uploaders/desk_image_uploader.rb
+++ b/app/uploaders/desk_image_uploader.rb
@@ -27,14 +27,6 @@ class DeskImageUploader < CarrierWave::Uploader::Base
     url == default_url
   end
 
-  # Process files as they are uploaded:
-  # process scale: [200, 300]
-  #
-  # def scale(width, height)
-  #   # do something
-  # end
-
-  # Create different versions of your uploaded files:
   # 詳細画面用の画像バージョン
   version :show do
     process resize_to_fit: [500, 300]
@@ -45,14 +37,13 @@ class DeskImageUploader < CarrierWave::Uploader::Base
     process resize_to_fill: [500, 300]
   end
 
+  # Google Cloud Vision API用の画像リサイズ
+  version :google_cloud do
+    process resize_to_fill: [300, 300]
+  end
+
   # アップロード可能なファイルの拡張子を指定
   def extension_allowlist
     %w[jpg jpeg gif png]
   end
-
-  # Override the filename of the uploaded files:
-  # Avoid using model.id or version_name here, see uploader/store.rb for details.
-  # def filename
-  #   "something.jpg"
-  # end
 end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ services:
     environment:
       POSTGRES_PASSWORD: password
       POSTGRES_USER: postgres
+      SELENIUM_DRIVER_URL: http://chrome:4444/wd/hub
     # ホストの5432ポート番号をコンテナの5432ポート番号にマッピング
     ports:
       - 5432:5432

--- a/spec/system/users_spec.rb
+++ b/spec/system/users_spec.rb
@@ -1,7 +1,38 @@
 require 'rails_helper'
 
 RSpec.describe "Users", type: :system do
-  before do
-    driven_by(:rack_test)
+  it '正しいタイトルが表示されていること' do
+    visit '/users/new'
+    expect(page).to have_title("ユーザー新規登録 | デスク色彩診断"), 'ユーザー登録ページのタイトルに「ユーザー新規登録 | デスク色彩診断」が含まれていません。'
   end
+
+  # context '入力情報正常系' do
+  #   it 'ユーザーが新規作成できること' do
+  #     visit '/users/new'
+  #     expect {
+  #       fill_in '姓', with: 'らんてっく'
+  #       fill_in '名', with: 'たろう'
+  #       fill_in 'メールアドレス', with: 'example@example.com'
+  #       fill_in 'パスワード', with: '12345678'
+  #       fill_in 'パスワード確認', with: '12345678'
+  #       click_button '登録'
+  #       Capybara.assert_current_path("/", ignore_query: true)
+  #     }.to change { User.count }.by(1)
+  #     expect(page).to have_content('ユーザー登録が完了しました'), 'フラッシュメッセージ「ユーザー登録が完了しました」が表示されていません'
+  #   end
+  # end
+
+  # context '入力情報異常系' do
+  #   it 'ユーザーが新規作成できない' do
+  #     visit '/users/new'
+  #     expect {
+  #       fill_in 'メールアドレス', with: 'example@example.com'
+  #       click_button '登録'
+  #     }.to change { User.count }.by(0)
+  #     expect(page).to have_content('ユーザー登録に失敗しました'), 'フラッシュメッセージ「ユーザー登録に失敗しました」が表示されていません'
+  #     expect(page).to have_content('姓を入力してください'), 'エラーメッセージ「姓を入力してください」が表示されていません'
+  #     expect(page).to have_content('名を入力してください'), 'フラッシュメッセージ「名を入力してください」が表示されていません'
+  #     expect(page).to have_content('パスワードは3文字以上で入力してください'), 'フラッシュメッセージ「パスワードは3文字以上で入力してください」が表示されていません'
+  #   end
+  # end
 end


### PR DESCRIPTION
#268 

# 概要
外部API使用時の通信負荷を削減するために以下を修正。

- [x] Cloud Vison APIに画像データを渡す前にリサイズしてサイズを小さくしてから渡す。

- app/uploaders/desk_image_uploader.rbでリサイズ設定バージョン追加
```ruby
  # Google Cloud Vision API用の画像リサイズ
  version :google_cloud do
    process resize_to_fill: [300, 300]
  end
```
- app/controllers/diagnoses_controller.rbの設定に反映
```ruby
  # 画像診断・色情報抽出
  def process_image
    # アップロードされたファイルが一時的に保存されているtmpファイルにアクセスするパス。(外部のAPIに送信に使用されるパス)
    uploaded_image = params[:diagnosis][:desk_image]
    uploader = DeskImageUploader.new
    uploader.cache!(uploaded_image)
    resized_image_path = uploader.google_cloud.file.path

    analyze_result = GoogleCloudVisionApi.analyze_image(resized_image_path) 
    @diagnosis.color_info = analyze_result if analyze_result
  end
```
- [x] ChatGPTでの診断文章生成の文字数上限を250→200に変更。
```ruby
class OpenAiApi
  def self.chat(color_info, desk_work)
    @client = OpenAI::Client.new(access_token: ENV['OPENAI_API_KEY'])
    @client.chat(
      parameters: {
        model: 'gpt-4',
        max_tokens: 200,
        messages: [
          {

   # 以下省略
```