### PR TITLE
Refact api 2

### DIFF
--- a/app/controllers/diagnoses_controller.rb
+++ b/app/controllers/diagnoses_controller.rb
@@ -51,12 +51,8 @@ class DiagnosesController < ApplicationController
   # 画像診断・色情報抽出
   def process_image
     # アップロードされたファイルが一時的に保存されているtmpファイルにアクセスするパス。(外部のAPIに送信に使用されるパス)
-    uploaded_image = params[:diagnosis][:desk_image]
-    uploader = DeskImageUploader.new
-    uploader.cache!(uploaded_image)
-    resized_image_path = uploader.google_cloud.file.path
-
-    analyze_result = GoogleCloudVisionApi.analyze_image(resized_image_path) 
+    uploaded_image_path = params[:diagnosis][:desk_image].tempfile.path
+    analyze_result = GoogleCloudVisionApi.analyze_image(uploaded_image_path) 
     @diagnosis.color_info = analyze_result if analyze_result
   end
 

--- a/app/uploaders/desk_image_uploader.rb
+++ b/app/uploaders/desk_image_uploader.rb
@@ -33,9 +33,9 @@ class DeskImageUploader < CarrierWave::Uploader::Base
   end
 
   # 一覧画面用の画像バージョン
-  version :index do
-    process resize_to_fill: [500, 300]
-  end
+  # version :index do
+  #   process resize_to_fill: [500, 300]
+  # end
 
   # Google Cloud Vision API用の画像リサイズ
   version :google_cloud do


### PR DESCRIPTION
# 概要
Googole Cloud Vision APIへの画像データの渡したを修正したが、本番環境でのストレージ環境差異によりエラーになったため、元に戻す。